### PR TITLE
Fix bad format syntax

### DIFF
--- a/PokeAlarm/WebhookStructs.py
+++ b/PokeAlarm/WebhookStructs.py
@@ -184,8 +184,8 @@ class RocketMap:
             'raid_begin': raid_begin,
             'lat': float(data['latitude']),
             'lng': float(data['longitude']),
-            'lat_5': "{.5f}".format(float(data['latitude'])),
-            'lng_5': "{.5f}".format(float(data['longitude']))
+            'lat_5': "{:.5f}".format(float(data['latitude'])),
+            'lng_5': "{:.5f}".format(float(data['longitude']))
         }
 
         egg['gmaps'] = get_gmaps_link(egg['lat'], egg['lng'])
@@ -240,8 +240,8 @@ class RocketMap:
             'raid_begin': raid_begin,
             'lat': float(data['latitude']),
             'lng': float(data['longitude']),
-            'lat_5': "{.5f}".format(float(data['latitude'])),
-            'lng_5': "{.5f}".format(float(data['longitude']))
+            'lat_5': "{:.5f}".format(float(data['latitude'])),
+            'lng_5': "{:.5f}".format(float(data['longitude']))
        }
 
         raid['gmaps'] = get_gmaps_link(raid['lat'], raid['lng'])


### PR DESCRIPTION
## Description
Resolves AttributeError: 'float' object has no attribute '5f' in `WebhookStructs.py` due to a bad format syntax

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
Bugfixing is always welcome

## How Has This Been Tested?
Running locally.

## Wiki Update
- [ ] This change requires an update to the Wiki.
- [X] This change does not require an update to the Wiki.


## Checklist
- [X] This change follows the code style of this project.
- [X] This change only changes what is necessary to the feature.
