### PR TITLE
Eggs expire when the raid starts, not when it ends

### DIFF
--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -843,8 +843,6 @@ class Manager(object):
 
         gym_id = egg['id']
 
-        raid_end = egg['raid_end']
-
         # Check if egg has been processed yet
         if self.__cache.get_egg_expiration(gym_id) is not None:
             if self.__quiet is False:
@@ -852,7 +850,7 @@ class Manager(object):
             return
 
         # Update egg hatch
-        self.__cache.update_egg_expiration(gym_id, raid_end)
+        self.__cache.update_egg_expiration(gym_id, egg['raid_begin'])
 
         # don't alert about (nearly) hatched eggs
         seconds_left = (egg['raid_begin'] - datetime.utcnow()).total_seconds()


### PR DESCRIPTION
## Description
In my opinion a cached egg webhook data should expire when the raid starts, not when it ends.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
I <3 being correct!

## How Has This Been Tested?
Local map.

## Wiki Update
- [ ] This change requires an update to the Wiki.
- [X] This change does not require an update to the Wiki.

## Checklist
- [X] This change follows the code style of this project.
- [X] This change only changes what is necessary to the feature.
