### PR TITLE
Simple file logging via --log <filename>

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -8,8 +8,7 @@
 #debug                          # Enables debugging mode
 #host:                          # Address to listen on (default 127.0.0.1)
 #port:                          # Port to listen on (default: 4000)
-#log_to_file                    # Enabled logging to file (default: false)
-#log_path:                      # Sets the path to log files if log_to_file is given (default: logs/)
+#log:                           # Enable logging to given filename
 #manager_count: 1               # Number of Managers to run. (default: 1)
 
 # Manager-Specific Settings

--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -5,21 +5,23 @@
 # To exclude an argument for a specific manager, use 'None'
 
 # Server Settings
-#debug											# Enables debugging mode
-#host:											# Address to listen on (default 127.0.0.1)
-#port:											# Port to listen on (default: 4000)
-#manager_count: 1								# Number of Managers to run. (default: 1)
+#debug                          # Enables debugging mode
+#host:                          # Address to listen on (default 127.0.0.1)
+#port:                          # Port to listen on (default: 4000)
+#log_to_file                    # Enabled logging to file (default: false)
+#log_path:                      # Sets the path to log files if log_to_file is given (default: logs/)
+#manager_count: 1               # Number of Managers to run. (default: 1)
 
 # Manager-Specific Settings
-#manager_name                                   # Name of the Manager in the logs. Default(manager_0).
-#key:                                           # Google Maps API Key to use
-#filters:										# File containing filter rules (default: filters.json)
-#alarms: 										# File containing alarm rules (default: alarms.json)
-#geofence:										# File containing geofence(s) used to filter (default: None)
-#location:										# Location for the manager. 'Name' or 'lat lng' (default: None)
-#locale:										# Language to be used to translate names (default: en)
-#cache_type:                                    # Specify the type of cache to use. Options: ['mem', 'file'] (Default: 'mem')
-#unit:											# Units used to measure distance. Either 'imperial' or 'metric' (default: imperial)
-#timelimit:										# Minimum number of seconds remaining to send a notification (default: 0)
-#max_attempts:									# Maximum number of attempts an alarm makes to send a notification. (default: 3)
-#timezone:                                      # Timezone used for notifications Ex: 'America/Los_Angeles' or '[America/Los_Angeles, America/New_York]'
+#manager_name                   # Name of the Manager in the logs. Default(manager_0).
+#key:                           # Google Maps API Key to use
+#filters:                       # File containing filter rules (default: filters.json)
+#alarms:                        # File containing alarm rules (default: alarms.json)
+#geofence:                      # File containing geofence(s) used to filter (default: None)
+#location:                      # Location for the manager. 'Name' or 'lat lng' (default: None)
+#locale:                        # Language to be used to translate names (default: en)
+#cache_type:                    # Specify the type of cache to use. Options: ['mem', 'file'] (Default: 'mem')
+#unit:                          # Units used to measure distance. Either 'imperial' or 'metric' (default: imperial)
+#timelimit:                     # Minimum number of seconds remaining to send a notification (default: 0)
+#max_attempts:                  # Maximum number of attempts an alarm makes to send a notification. (default: 3)
+#timezone:                      # Timezone used for notifications Ex: 'America/Los_Angeles' or '[America/Los_Angeles, America/New_York]'

--- a/start_pokealarm.py
+++ b/start_pokealarm.py
@@ -19,7 +19,6 @@ import Queue
 import json
 import os
 import sys
-from time import strftime
 # 3rd Party Imports
 from flask import Flask, request, abort
 # Local Imports
@@ -174,25 +173,13 @@ def parse_settings(root_path):
     parser.add_argument(
         '-tz', '--timezone', type=str, action='append', default=[None],
         help='Timezone used for notifications. Ex: "America/Los_Angeles"')
-    parser.add_argument('--log_to_file',
-                        help=('Enable logging to file.'),
-                        action='store_true', default=False)
-    parser.add_argument('--log_path',
-                        help=('Defines directory to save log files to.'),
-                        default='logs/')
+    parser.add_argument(
+        '--log', help='Log output to given file.')
 
     args = parser.parse_args()
 
-    if args.log_to_file:
-        # Create directory for log files.
-        if not os.path.exists(args.log_path):
-            os.mkdir(args.log_path)
-        date = strftime('%Y%m%d_%H%M')
-        filename = os.path.join(args.log_path, '{}.log'.format(date))
-        fh = logging.FileHandler(filename)
-        fh.setFormatter(
-            logging.Formatter(fmt='%(asctime)s [%(processName)15.15s][%(name)10.10s][%(levelname)8.8s] %(message)s'))
-        logging.root.addHandler(fh)
+    if args.log:
+        configure_file_logging(args.log)
 
     if args.debug:
         log.setLevel(logging.DEBUG)
@@ -272,6 +259,23 @@ def parse_settings(root_path):
     # Set up signal handlers for graceful exit
     signal(signal.SIGINT, exit_gracefully)
     signal(signal.SIGTERM, exit_gracefully)
+
+
+def configure_file_logging(log_file):
+    path, filename = os.path.split(log_file)
+    if not os.path.exists(path):
+        try:
+            os.makedirs(path)
+        except OSError:
+            log.exception("Could not enable logging to file.")
+            return
+    if os.access(path, os.W_OK):
+        fh = logging.FileHandler(log_file)
+        fh.setFormatter(
+            logging.Formatter(
+                fmt='%(asctime)s [%(processName)15.15s][%(name)10.10s]'
+                    + '[%(levelname)8.8s] %(message)s'))
+        logging.root.addHandler(fh)
 
 
 # Because lists are dumb and don't have a failsafe get

--- a/start_pokealarm.py
+++ b/start_pokealarm.py
@@ -19,6 +19,7 @@ import Queue
 import json
 import os
 import sys
+from time import strftime
 # 3rd Party Imports
 from flask import Flask, request, abort
 # Local Imports
@@ -173,8 +174,25 @@ def parse_settings(root_path):
     parser.add_argument(
         '-tz', '--timezone', type=str, action='append', default=[None],
         help='Timezone used for notifications. Ex: "America/Los_Angeles"')
+    parser.add_argument('--log_to_file',
+                        help=('Enable logging to file.'),
+                        action='store_true', default=False)
+    parser.add_argument('--log_path',
+                        help=('Defines directory to save log files to.'),
+                        default='logs/')
 
     args = parser.parse_args()
+
+    if args.log_to_file:
+        # Create directory for log files.
+        if not os.path.exists(args.log_path):
+            os.mkdir(args.log_path)
+        date = strftime('%Y%m%d_%H%M')
+        filename = os.path.join(args.log_path, '{}.log'.format(date))
+        fh = logging.FileHandler(filename)
+        fh.setFormatter(
+            logging.Formatter(fmt='%(asctime)s [%(processName)15.15s][%(name)10.10s][%(levelname)8.8s] %(message)s'))
+        logging.root.addHandler(fh)
 
     if args.debug:
         log.setLevel(logging.DEBUG)


### PR DESCRIPTION
## Description
If given `--log <filename>` on command line or in `config.ini` PokeAlarm logs everything you see on screen to the given log file. The log line format is the same as the screen output.

I also removed some whitespace from `config.ini.example` and replaced tabs with spaces for better readability.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
In order to debug some things I added very simple logging to file for later investigations.

## How Has This Been Tested?
Local and remote installations

## Wiki Update
- [X] This change requires an update to the Wiki.
- [ ] This change does not require an update to the Wiki.

## Checklist
- [X] This change follows the code style of this project.
- [X] This change only changes what is necessary to the feature.
