### PR TITLE
Big Magikarp / Tiny Ratatta values exact

### DIFF
--- a/PokeAlarm/WebhookStructs.py
+++ b/PokeAlarm/WebhookStructs.py
@@ -96,10 +96,10 @@ class RocketMap:
             pkmn['height'] = "{:.2f}".format(pkmn['height'])
             pkmn['weight'] = "{:.2f}".format(pkmn['weight'])
 
-        if pkmn['pkmn_id'] == 19 and pkmn['size'] == 'tiny':
+        if pkmn['pkmn_id'] == 19 and pkmn['weight'] <= 2.41:
             pkmn['tiny_rat'] = 'tiny'
 
-        if pkmn['pkmn_id'] == 129 and pkmn['size'] == 'big':
+        if pkmn['pkmn_id'] == 129 and pkmn['weight'] >= 13.13:
             pkmn['big_karp'] = 'big'
 
         # Todo: Remove this when monocle get's it's own standard


### PR DESCRIPTION
## Description
Fixes issues with Magikarp being mislabed as "Big" and Ratatta being mislabeled as "Tiny" for the associated medals.
Fixes #429 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
Currently the way we check to see if big Magikarp and tiny Ratatta are big or tiny is by generic size
Big > 2.5
XS < 1.5
As it turns out this isn't correct, and based off research, the "bigness" or "smallness" isn't determined by height in the slightest, but by weight only.

## How Has This Been Tested?
Poorly. (Have no level 30s to test with)

## Screenshots (if appropriate):
Nerp

## Wiki Update
- [ ] This change requires an update to the Wiki.
- [x] This change does not require an update to the Wiki.


## Checklist
- [x] This change follows the code style of this project.
- [x] This change only changes what is necessary to the feature.
