### PR TITLE
Twilio Multi "To_Number" Support

### DIFF
--- a/PokeAlarm/Twilio/TwilioAlarm.py
+++ b/PokeAlarm/Twilio/TwilioAlarm.py
@@ -74,7 +74,7 @@ class TwilioAlarm(Alarm):
                 to_num=self.__to_number,
                 from_num=self.__from_number,
                 body="PokeAlarm activated!"
-                )
+            )
             log.info("Startup message sent!")
 
     # Set the appropriate settings for each alert
@@ -89,11 +89,11 @@ class TwilioAlarm(Alarm):
 
     # Send Pokemon Info
     def send_alert(self, alert, info):
-            self.send_sms(
-                to_num=alert['to_number'],
-                from_num=alert['from_number'],
-                body=replace(alert['message'], info)
-            )
+        self.send_sms(
+            to_num=alert['to_number'],
+            from_num=alert['from_number'],
+            body=replace(alert['message'], info)
+        )
 
     # Trigger an alert based on Pokemon info
     def pokemon_alert(self, pokemon_info):
@@ -117,17 +117,11 @@ class TwilioAlarm(Alarm):
 
     # Send a SMS message
     def send_sms(self, to_num, from_num, body):
-        if isinstance(to_num, list):
-            for num in to_num:
-                args={
-                    'to': num,
-                    'from_': from_num,
-                    'body': body
-                }
-                try_sending(log, self.connect, "Twilio", self.__client.messages.create, args)
-        else:
-            args = {
-                'to': to_num,
+        if not isinstance(to_num, list):
+           to_num = [to_num]
+        for num in to_num:
+            args={
+                'to': num,
                 'from_': from_num,
                 'body': body
             }

--- a/PokeAlarm/Twilio/TwilioAlarm.py
+++ b/PokeAlarm/Twilio/TwilioAlarm.py
@@ -74,7 +74,7 @@ class TwilioAlarm(Alarm):
                 to_num=self.__to_number,
                 from_num=self.__from_number,
                 body="PokeAlarm activated!"
-            )
+                )
             log.info("Startup message sent!")
 
     # Set the appropriate settings for each alert
@@ -89,11 +89,11 @@ class TwilioAlarm(Alarm):
 
     # Send Pokemon Info
     def send_alert(self, alert, info):
-        self.send_sms(
-            to_num=alert['to_number'],
-            from_num=alert['from_number'],
-            body=replace(alert['message'], info)
-        )
+            self.send_sms(
+                to_num=alert['to_number'],
+                from_num=alert['from_number'],
+                body=replace(alert['message'], info)
+            )
 
     # Trigger an alert based on Pokemon info
     def pokemon_alert(self, pokemon_info):
@@ -117,9 +117,18 @@ class TwilioAlarm(Alarm):
 
     # Send a SMS message
     def send_sms(self, to_num, from_num, body):
-        args = {
-            'to': to_num,
-            'from_': from_num,
-            'body': body
-        }
-        try_sending(log, self.connect, "Twilio", self.__client.messages.create, args)
+        if isinstance(to_num, list):
+            for num in to_num:
+                args={
+                    'to': num,
+                    'from_': from_num,
+                    'body': body
+                }
+                try_sending(log, self.connect, "Twilio", self.__client.messages.create, args)
+        else:
+            args = {
+                'to': to_num,
+                'from_': from_num,
+                'body': body
+            }
+            try_sending(log, self.connect, "Twilio", self.__client.messages.create, args)


### PR DESCRIPTION
## Description
This PR adds support for sending alerts to multiple numbers via a Twilio.  This works by replacing the  `to_number` field of the alarm setting with an array of numbers.  

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
This was a requested feature under https://github.com/PokeAlarm/PokeAlarm/issues/452.  The feature gives the ability to subscribe multiple recipients for PokeAlarm alerts through Twilio. 

## How Has This Been Tested?
This was tested through my trial Twilio account using both a single number destination and an array of up to 3 individual numbers.  Tests were performed using the webhook_test utility. 

## Screenshots (if appropriate):
N/A

## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change to https://github.com/RocketMap/PokeAlarmWiki.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [x] This change requires an update to the Wiki.
- [ ] This change does not require an update to the Wiki.

The wiki will need to be updated to indicate the changes to use the alert appropriately.  

## Checklist
- [x] This change follows the code style of this project.
- [x] This change only changes what is necessary to the feature.
