### PR TITLE
Adding <team_leader> DTS to raids and eggs

### DIFF
--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -1024,7 +1024,8 @@ class Manager(object):
             "dist": get_dist_as_str(dist),
             'dir': get_cardinal_dir([lat, lng], self.__location),
             'team_id': team_id,
-            'team_name': self.__locale.get_team_name(team_id)
+            'team_name': self.__locale.get_team_name(team_id),
+            'team_leader': self.__locale.get_leader_name(team_id)
         })
 
         threads = []
@@ -1153,6 +1154,7 @@ class Manager(object):
             'form_or_empty': '' if form == 'unknown' else form,
             'team_id': team_id,
             'team_name': self.__locale.get_team_name(team_id),
+            'team_leader': self.__locale.get_leader_name(team_id),
             'min_cp': min_cp,
             'max_cp': max_cp
         })


### PR DESCRIPTION
## Description
Very simple addition of a DTS tag <team_leader> to other events including raids and eggs.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
Wanted to get team leaders to call out raids and eggs so players would know who controls the gym. Also for potential future color embed feature.

## How Has This Been Tested?
Myself, Yes it very simple and breaks nothing

## Screenshots (if appropriate):


## Wiki Update
- [x] This change requires an update to the Wiki.
- [ ] This change does not require an update to the Wiki.


## Checklist
- [x] This change follows the code style of this project.
- [x] This change only changes what is necessary to the feature.
