### PR TITLE
Updating  to add Magikarp back as a raid boss

### DIFF
--- a/filters.json.example
+++ b/filters.json.example
@@ -450,7 +450,7 @@
         "Ninetales":"True",
         "Scyther":"True",
         "Omastar":"True",
-	"Magikarp":"True",
+        "Magikarp":"True",
         "Porygon":"True",
         "Alakazam":"True",
         "Gengar":"True",

--- a/filters.json.example
+++ b/filters.json.example
@@ -450,6 +450,7 @@
         "Ninetales":"True",
         "Scyther":"True",
         "Omastar":"True",
+	"Magikarp":"True",
         "Porygon":"True",
         "Alakazam":"True",
         "Gengar":"True",


### PR DESCRIPTION
## Description
With the recent announcement on RAID Changes, Magikarp is once again a raid boss, so adding him back to the filters example file. 

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
**MAGIKARP IS BACK!** 

## How Has This Been Tested?
No testing needed, no functional change made. 

## Screenshots (if appropriate):
N/A

## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change to https://github.com/RocketMap/PokeAlarmWiki.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [ ] This change requires an update to the Wiki.
- [x] This change does not require an update to the Wiki.


## Checklist
- [x] This change follows the code style of this project.
- [x] This change only changes what is necessary to the feature.
