### PR TITLE
Fixed ValueError: '=' alignment bug

### DIFF
--- a/PokeAlarm/Events/MonEvent.py
+++ b/PokeAlarm/Events/MonEvent.py
@@ -100,7 +100,7 @@ class MonEvent(BaseEvent):
             'encounter_id': self.enc_id,
             'mon_name': locale.get_pokemon_name(self.monster_id),
             'mon_id': self.monster_id,
-            'mon_id_3': "{:03}".format(self.monster_id),
+            'mon_id_3': str(self.monster_id).rjust(3, '0'),
 
             # Time Remaining
             'time_left': time[0],
@@ -145,7 +145,7 @@ class MonEvent(BaseEvent):
             'form': form_name,
             'form_or_empty': Unknown.or_empty(form_name),
             'form_id': self.form_id,
-            'form_id_3': "{:03d}".format(self.form_id),
+            'form_id_3': str(self.form_id).rjust(3, '0'),
 
             # Quick Move
             'quick_move': locale.get_move_name(self.quick_move_id),

--- a/PokeAlarm/Events/RaidEvent.py
+++ b/PokeAlarm/Events/RaidEvent.py
@@ -90,7 +90,7 @@ class RaidEvent(BaseEvent):
             'raid_lvl': self.raid_lvl,
             'mon_name': locale.get_pokemon_name(self.mon_id),
             'mon_id': self.mon_id,
-            'mon_id_3': "{:03}".format(self.mon_id),
+            'mon_id_3': str(self.mon_id).rjust(3, '0'),
             # TODO: Form?
 
             # Quick Move


### PR DESCRIPTION
## Description
Fix the bug related to string formatting not padding zeros appropriately with ints
Also changed other places that use the `{:03}` string formatting pattern to this way to avoid other conflicts

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
There have been several people who say that they get this error (which I got directly from someone effected):
```
  File "C:\PokeAlarm\PokeAlarm\Manager.py", line 388, in run
    self.process_raid(event)
  File "C:\PokeAlarm\PokeAlarm\Manager.py", line 750, in process_raid
    dts = raid.generate_dts(self.__locale)
  File "C:\PokeAlarm\PokeAlarm\Events\RaidEvent.py", line 93, in generate_dts
    'mon_id_3': "{:03}".format(self.mon_id),
ValueError: '=' alignment not allowed in string format specifier
```

## How Has This Been Tested?
Tested on Windows 10 using the webhook tester. Forms, images and everything seems to be appropriate

## Wiki Update
- [ ] This change requires an update to the Wiki.
- [x] This change does not require an update to the Wiki.


## Checklist
- [x] This change follows the code style of this project.
- [x] This change only changes what is necessary to the feature.
