### PR TITLE
Unit testing for Eggs, Raids, Gyms

### DIFF
--- a/PokeAlarm/Events/EggEvent.py
+++ b/PokeAlarm/Events/EggEvent.py
@@ -41,7 +41,10 @@ class EggEvent(BaseEvent):
             str, data.get('description'), Unknown.REGULAR).strip()
         self.gym_image = check_for_none(
             str, data.get('url'), Unknown.REGULAR)
-        self.current_team_id = Unknown.TINY
+
+        # Gym Team (this is only available from cache)
+        self.current_team_id = check_for_none(
+            int, data.get('team'), Unknown.TINY)
 
         self.name = self.gym_id
         self.geofence = Unknown.REGULAR

--- a/PokeAlarm/Events/RaidEvent.py
+++ b/PokeAlarm/Events/RaidEvent.py
@@ -53,7 +53,10 @@ class RaidEvent(BaseEvent):
             str, data.get('description'), Unknown.REGULAR).strip()
         self.gym_image = check_for_none(
             str, data.get('url'), Unknown.REGULAR)
-        self.current_team_id = Unknown.TINY  # Will set later
+
+        # Gym Team (this is only available from cache)
+        self.current_team_id = check_for_none(
+            int, data.get('team'), Unknown.TINY)
 
         self.name = self.gym_id
         self.geofence = Unknown.REGULAR

--- a/PokeAlarm/Filters/BaseFilter.py
+++ b/PokeAlarm/Filters/BaseFilter.py
@@ -24,7 +24,7 @@ class BaseFilter(object):
         self._check_list = []
 
         # Missing Info
-        self.missing_info = None
+        self.is_missing_info = None
 
     def to_dict(self):
         """ Create a dict representation of this Event. """
@@ -34,15 +34,16 @@ class BaseFilter(object):
         return json.dumps(self.to_dict(), indent=4, sort_keys=True)
 
     def check_event(self, event):
-        missing = False  # Is the event missing needed info?
+        missing = False  # Event is missing no info to start
         for check in self._check_list:
             result = check(self, event)
             if result is False:
                 return False
             elif Unknown.is_(result):
-                missing = True
+                missing = True  # Mark Event as missing info
         # Do a special check for is missing_info is set
-        if self.missing_info is not None and missing == self.missing_info:
+        if self.is_missing_info is not None \
+                and missing != self.is_missing_info:
             self.reject(event, "needed information was missing.")
             return False
         return True

--- a/PokeAlarm/Filters/EggFilter.py
+++ b/PokeAlarm/Filters/EggFilter.py
@@ -51,8 +51,8 @@ class EggFilter(BaseFilter):
             str, str, 'custom_dts', data)
 
         # Missing Info
-        self.missing_info = BaseFilter.parse_as_type(
-            bool, 'missing_info', data)
+        self.is_missing_info = BaseFilter.parse_as_type(
+            bool, 'is_missing_info', data)
 
         # Reject leftover parameters
         for key in data:
@@ -84,7 +84,7 @@ class EggFilter(BaseFilter):
             settings['geofences'] = self.geofences
 
         # Missing Info
-        if self.missing_info is not None:
-            settings['missing_info'] = self.missing_info
+        if self.is_missing_info is not None:
+            settings['missing_info'] = self.is_missing_info
 
         return settings

--- a/PokeAlarm/Filters/GymFilter.py
+++ b/PokeAlarm/Filters/GymFilter.py
@@ -46,8 +46,8 @@ class GymFilter(BaseFilter):
             str, str, 'custom_dts', data)
 
         # Missing Info
-        self.missing_info = BaseFilter.parse_as_type(
-            bool, 'missing_info', data)
+        self.is_missing_info = BaseFilter.parse_as_type(
+            bool, 'is_missing_info', data)
 
         # Reject leftover parameters
         for key in data:
@@ -79,7 +79,7 @@ class GymFilter(BaseFilter):
             settings['geofences'] = self.geofences
 
         # Missing Info
-        if self.missing_info is not None:
-            settings['missing_info'] = self.missing_info
+        if self.is_missing_info is not None:
+            settings['missing_info'] = self.is_missing_info
 
         return settings

--- a/PokeAlarm/Filters/MonFilter.py
+++ b/PokeAlarm/Filters/MonFilter.py
@@ -113,8 +113,8 @@ class MonFilter(BaseFilter):
             str, str, 'custom_dts', data)
 
         # Missing Info
-        self.missing_info = BaseFilter.parse_as_type(
-            bool, 'missing_info', data)
+        self.is_missing_info = BaseFilter.parse_as_type(
+            bool, 'is_missing_info', data)
 
         # Reject leftover parameters
         for key in data:
@@ -192,7 +192,7 @@ class MonFilter(BaseFilter):
             settings['geofences'] = self.geofences
 
         # Missing Info
-        if self.missing_info is not None:
-            settings['missing_info'] = self.missing_info
+        if self.is_missing_info is not None:
+            settings['missing_info'] = self.is_missing_info
 
         return settings

--- a/PokeAlarm/Filters/RaidFilter.py
+++ b/PokeAlarm/Filters/RaidFilter.py
@@ -68,8 +68,8 @@ class RaidFilter(BaseFilter):
             str, str, 'custom_dts', data)
 
         # Missing Info
-        self.missing_info = BaseFilter.parse_as_type(
-            bool, 'missing_info', data)
+        self.is_missing_info = BaseFilter.parse_as_type(
+            bool, 'is_missing_info', data)
 
         # Reject leftover parameters
         for key in data:
@@ -104,7 +104,7 @@ class RaidFilter(BaseFilter):
             settings['geofences'] = self.geofences
 
         # Missing Info
-        if self.missing_info is not None:
-            settings['missing_info'] = self.missing_info
+        if self.is_missing_info is not None:
+            settings['missing_info'] = self.is_missing_info
 
         return settings

--- a/PokeAlarm/Filters/StopFilter.py
+++ b/PokeAlarm/Filters/StopFilter.py
@@ -28,8 +28,8 @@ class StopFilter(BaseFilter):
             str, str, 'custom_dts', data)
 
         # Missing Info
-        self.missing_info = BaseFilter.parse_as_type(
-            bool, 'missing_info', data)
+        self.is_missing_info = BaseFilter.parse_as_type(
+            bool, 'is_missing_info', data)
 
         # Reject leftover parameters
         for key in data:
@@ -51,7 +51,7 @@ class StopFilter(BaseFilter):
             settings['geofences'] = self.geofences
 
         # Missing Info
-        if self.missing_info is not None:
-            settings['missing_info'] = self.missing_info
+        if self.is_missing_info is not None:
+            settings['missing_info'] = self.is_missing_info
 
         return settings

--- a/PokeAlarm/Utilities/GymUtils.py
+++ b/PokeAlarm/Utilities/GymUtils.py
@@ -10,7 +10,7 @@ from PokeAlarm.Utils import get_path
 # (use all locales for flexibility)
 def get_team_id(team_name):
     try:
-        name = team_name.lower()
+        name = str(team_name).lower()
         if not hasattr(get_team_id, 'ids'):
             get_team_id.ids = {}
             files = glob(get_path('locales/*.json'))

--- a/PokeAlarm/Utilities/MonUtils.py
+++ b/PokeAlarm/Utilities/MonUtils.py
@@ -33,7 +33,7 @@ def get_monster_id(pokemon_name):
 # Returns the id corresponding with the move (use all locales for flexibility)
 def get_move_id(move_name):
     try:
-        name = move_name.lower()
+        name = str(move_name).lower()
         if not hasattr(get_move_id, 'ids'):
             get_move_id.ids = {}
             files = glob(get_path('locales/*.json'))

--- a/filters.json.example
+++ b/filters.json.example
@@ -19,7 +19,7 @@
                 "sizes": [ "tiny", "small", "normal", "large", "big" ],
                 "geofences": [ "Central Park" ],
                 "custom_dts": { "key1": "value1", "key2": "value2" },
-                "missing_info": false
+                "is_missing_info": false
             }
         }
     },
@@ -32,7 +32,7 @@
                 "min_dist": 0, "max_dist": "inf",
                 "custom_dts": { "key1": "value1", "key2": "value2" },
                 "geofences": [ "Central Park" ],
-                "missing_info": false
+                "is_missing_info": false
             }
         }
     },
@@ -49,7 +49,7 @@
                 "gym_name_matches": [ ".*" ],
                 "geofences": [ "Central Park" ],
                 "custom_dts": { "key1": "value1", "key2": "value2" },
-                "missing_info": false
+                "is_missing_info": false
             }
         }
     },
@@ -65,7 +65,7 @@
                 "gym_name_matches": [ ".*" ],
                 "geofences": [ "Central Park" ],
                 "custom_dts": { "key1": "value1", "key2": "value2" },
-                "missing_info": false
+                "is_missing_info": false
             }
         }
     },
@@ -84,7 +84,7 @@
                 "gym_name_matches": [ ".*" ],
                 "geofences": [ "Central Park" ],
                 "custom_dts": { "key1": "value1", "key2": "value2" },
-                "missing_info": false
+                "is_missing_info": false
             }
         }
     }

--- a/tests/filters/test_egg_filter.py
+++ b/tests/filters/test_egg_filter.py
@@ -76,22 +76,22 @@ class TestEggFilter(unittest.TestCase):
 
     def test_missing_info1(self):
         # Create the filters
-        settings = {"missing_info": True}
+        settings = {"max_dist": "inf", "is_missing_info": True}
         egg_filter = Filters.EggFilter('filter1', settings)
 
         # Generate events that should pass
-        pass1 = Events.EggEvent(generate_egg({}))
+        pass1 = Events.EggEvent(generate_egg({"distance": "Unknown"}))
         # Test passing events
         for e in [pass1]:
             self.assertTrue(egg_filter.check_event(e))
 
     def test_missing_info2(self):
         # Create the filters
-        settings = {"missing_info": False}
+        settings = {"max_dist": "inf", "is_missing_info": False}
         egg_filter = Filters.EggFilter('filter1', settings)
 
         # Generate events that should pass
-        pass1 = Events.EggEvent(generate_egg({}))
+        pass1 = Events.EggEvent(generate_egg({"distance": 1000}))
         # Test passing events
         for e in [pass1]:
             self.assertTrue(egg_filter.check_event(e))

--- a/tests/filters/test_egg_filter.py
+++ b/tests/filters/test_egg_filter.py
@@ -1,0 +1,116 @@
+import unittest
+import PokeAlarm.Filters as Filters
+import PokeAlarm.Events as Events
+
+
+class TestEggFilter(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_egg_lvl(self):
+        # Create the filters
+        settings = {"min_egg_lvl": 3, "max_egg_lvl": 5}
+        egg_filter = Filters.EggFilter('filter1', settings)
+
+        # Generate events that should pass
+        pass1 = Events.EggEvent(generate_egg({"level": 3}))
+        pass2 = Events.EggEvent(generate_egg({"level": 4}))
+        pass3 = Events.EggEvent(generate_egg({"level": 5}))
+        # Test passing events
+        for e in [pass1, pass2, pass3]:
+            self.assertTrue(egg_filter.check_event(e))
+
+        # Generate events that should fail
+        fail1 = Events.EggEvent(generate_egg({"level": 1}))
+        fail2 = Events.EggEvent(generate_egg({"level": 2}))
+
+        # Test failing events
+        for e in [fail1, fail2]:
+            self.assertFalse(egg_filter.check_event(e))
+			
+    def test_egg_dist(self):
+        # Create the filters
+        settings = {"min_dist": 200, "max_dist": 500}
+        egg_filter = Filters.EggFilter('filter1', settings)
+
+        # Generate events that should pass
+        pass1 = Events.EggEvent(generate_egg({"distance": 200}))
+        pass2 = Events.EggEvent(generate_egg({"distance": 350}))
+        pass3 = Events.EggEvent(generate_egg({"distance": 500}))
+        # Test passing events
+        for e in [pass1, pass2, pass3]:
+            self.assertTrue(egg_filter.check_event(e))
+
+        # Generate events that should fail
+        fail1 = Events.EggEvent(generate_egg({"distance": 100}))
+        fail2 = Events.EggEvent(generate_egg({"distance": 199}))
+        fail3 = Events.EggEvent(generate_egg({"distance": 501}))
+
+        # Test failing events
+        for e in [fail1, fail2, fail3]:
+            self.assertFalse(egg_filter.check_event(e))
+
+    def test_gym_names(self):
+        # Create the filters
+        settings = {"gym_name_matches": ["pass.\Z"]}
+        egg_filter = Filters.EggFilter('filter1', settings)
+
+        # Generate events that should pass
+        pass1 = Events.EggEvent(generate_egg({"name": "pass1"}))
+        pass2 = Events.EggEvent(generate_egg({"name": "pass2"}))
+        pass3 = Events.EggEvent(generate_egg({"name": "pass3"}))
+        # Test passing events
+        for e in [pass1, pass2, pass3]:
+            self.assertTrue(egg_filter.check_event(e))
+
+        # Generate events that should fail
+        fail1 = Events.EggEvent(generate_egg({"name": "fail1"}))
+        fail2 = Events.EggEvent(generate_egg({"name": "failpass"}))
+        fail3 = Events.EggEvent(generate_egg({"name": "passfail"}))
+
+        # Test failing events
+        for e in [fail1, fail2, fail3]:
+            self.assertFalse(egg_filter.check_event(e))
+
+    def test_current_team(self):
+        # Create the filters
+        settings = {"current_teams": [1, "2", "Instinct"]}
+        egg_filter = Filters.EggFilter('filter1', settings)
+
+        # Generate events that should pass
+        pass1 = Events.EggEvent(generate_egg({"team": 1}))
+        pass2 = Events.EggEvent(generate_egg({"team": 2}))
+        pass3 = Events.EggEvent(generate_egg({"team": 3}))
+        # Test passing events
+        for e in [pass1, pass2, pass3]:
+            self.assertTrue(egg_filter.check_event(e))
+
+        # Generate events that should fail
+        fail1 = Events.EggEvent(generate_egg({"team": 0}))
+
+        # Test failing events
+        for e in [fail1]:
+            self.assertFalse(egg_filter.check_event(e))
+
+# Create a generic egg, overriding with an specific values
+def generate_egg(values):
+    egg = {
+        "gym_id": "OWNmOTFmMmM0YTY3NGQwYjg0Y2I1N2JlZjU4OWRkMTYuMTY=",
+        "url": "???",
+        "name": "unknown",
+        "description": "???",
+        "start": 1499244052,
+        "end": 1499246052,
+        "level": 5,
+        "latitude": 37.7876146,
+        "longitude": -122.390624
+    }
+    egg.update(values)
+    return egg
+	
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/filters/test_egg_filter.py
+++ b/tests/filters/test_egg_filter.py
@@ -80,7 +80,7 @@ class TestEggFilter(unittest.TestCase):
         egg_filter = Filters.EggFilter('filter1', settings)
 
         # Generate events that should pass
-        pass1 = Events.EggEvent(generate_egg({"distance": "Unknown"}))
+        pass1 = Events.EggEvent(generate_egg({"dist": "Unknown"}))
         # Test passing events
         for e in [pass1]:
             self.assertTrue(egg_filter.check_event(e))
@@ -91,10 +91,41 @@ class TestEggFilter(unittest.TestCase):
         egg_filter = Filters.EggFilter('filter1', settings)
 
         # Generate events that should pass
-        pass1 = Events.EggEvent(generate_egg({"distance": 1000}))
+        pass1 = Events.EggEvent(generate_egg({}))
+        pass1.distance = 1000
+
         # Test passing events
         for e in [pass1]:
             self.assertTrue(egg_filter.check_event(e))
+
+    def test_egg_distance(self):
+        # Create the filters
+        settings = {"max_dist": "2000", "min_dist": "400"}
+        egg_filter = Filters.EggFilter('filter1', settings)
+
+        # Generate events that should pass
+        pass1 = Events.EggEvent(generate_egg({}))
+        pass1.distance = 1000
+        pass2 = Events.EggEvent(generate_egg({}))
+        pass2.distance = 800
+        pass3 = Events.EggEvent(generate_egg({}))
+        pass3.distance = 600
+
+        # Test passing events
+        for e in [pass1]:
+            self.assertTrue(egg_filter.check_event(e))
+
+        # Generate events that should fail
+        fail1 = Events.EggEvent(generate_egg({}))
+        fail1.distance = 3000
+        fail2 = Events.EggEvent(generate_egg({}))
+        fail2.distance = 300
+        fail3 = Events.EggEvent(generate_egg({}))
+        fail3.distance = 0
+
+        # Test failing events
+        for e in [fail1, fail2, fail3]:
+            self.assertFalse(egg_filter.check_event(e))
 
     def test_custom_dts(self):
         # Create the filters
@@ -103,6 +134,7 @@ class TestEggFilter(unittest.TestCase):
 
         # Generate events that should pass
         pass1 = Events.EggEvent(generate_egg({}))
+		
         # Test passing events
         for e in [pass1]:
             self.assertTrue(egg_filter.check_event(e))

--- a/tests/filters/test_egg_filter.py
+++ b/tests/filters/test_egg_filter.py
@@ -134,7 +134,7 @@ class TestEggFilter(unittest.TestCase):
 
         # Generate events that should pass
         pass1 = Events.EggEvent(generate_egg({}))
-		
+
         # Test passing events
         for e in [pass1]:
             self.assertTrue(egg_filter.check_event(e))

--- a/tests/filters/test_egg_filter.py
+++ b/tests/filters/test_egg_filter.py
@@ -74,9 +74,20 @@ class TestEggFilter(unittest.TestCase):
         for e in [fail1]:
             self.assertFalse(egg_filter.check_event(e))
 
-    def test_missing_info(self):
+    def test_missing_info1(self):
         # Create the filters
         settings = {"missing_info": True}
+        egg_filter = Filters.EggFilter('filter1', settings)
+
+        # Generate events that should pass
+        pass1 = Events.EggEvent(generate_egg({}))
+        # Test passing events
+        for e in [pass1]:
+            self.assertTrue(egg_filter.check_event(e))
+
+    def test_missing_info2(self):
+        # Create the filters
+        settings = {"missing_info": False}
         egg_filter = Filters.EggFilter('filter1', settings)
 
         # Generate events that should pass

--- a/tests/filters/test_egg_filter.py
+++ b/tests/filters/test_egg_filter.py
@@ -13,45 +13,23 @@ class TestEggFilter(unittest.TestCase):
 
     def test_egg_lvl(self):
         # Create the filters
-        settings = {"min_egg_lvl": 3, "max_egg_lvl": 5}
+        settings = {"min_egg_lvl": 2, "max_egg_lvl": 4}
         egg_filter = Filters.EggFilter('filter1', settings)
 
         # Generate events that should pass
-        pass1 = Events.EggEvent(generate_egg({"level": 3}))
-        pass2 = Events.EggEvent(generate_egg({"level": 4}))
-        pass3 = Events.EggEvent(generate_egg({"level": 5}))
+        pass1 = Events.EggEvent(generate_egg({"level": 2}))
+        pass2 = Events.EggEvent(generate_egg({"level": 3}))
+        pass3 = Events.EggEvent(generate_egg({"level": 4}))
         # Test passing events
         for e in [pass1, pass2, pass3]:
             self.assertTrue(egg_filter.check_event(e))
 
         # Generate events that should fail
         fail1 = Events.EggEvent(generate_egg({"level": 1}))
-        fail2 = Events.EggEvent(generate_egg({"level": 2}))
+        fail2 = Events.EggEvent(generate_egg({"level": 5}))
 
         # Test failing events
         for e in [fail1, fail2]:
-            self.assertFalse(egg_filter.check_event(e))
-
-    def test_egg_dist(self):
-        # Create the filters
-        settings = {"min_dist": 200, "max_dist": 500}
-        egg_filter = Filters.EggFilter('filter1', settings)
-
-        # Generate events that should pass
-        pass1 = Events.EggEvent(generate_egg({"distance": 200}))
-        pass2 = Events.EggEvent(generate_egg({"distance": 350}))
-        pass3 = Events.EggEvent(generate_egg({"distance": 500}))
-        # Test passing events
-        for e in [pass1, pass2, pass3]:
-            self.assertTrue(egg_filter.check_event(e))
-
-        # Generate events that should fail
-        fail1 = Events.EggEvent(generate_egg({"distance": 100}))
-        fail2 = Events.EggEvent(generate_egg({"distance": 199}))
-        fail3 = Events.EggEvent(generate_egg({"distance": 501}))
-
-        # Test failing events
-        for e in [fail1, fail2, fail3]:
             self.assertFalse(egg_filter.check_event(e))
 
     def test_gym_names(self):
@@ -95,6 +73,28 @@ class TestEggFilter(unittest.TestCase):
         # Test failing events
         for e in [fail1]:
             self.assertFalse(egg_filter.check_event(e))
+
+    def test_missing_info(self):
+        # Create the filters
+        settings = {"missing_info": True}
+        egg_filter = Filters.EggFilter('filter1', settings)
+
+        # Generate events that should pass
+        pass1 = Events.EggEvent(generate_egg({}))
+        # Test passing events
+        for e in [pass1]:
+            self.assertTrue(egg_filter.check_event(e))
+
+    def test_custom_dts(self):
+        # Create the filters
+        settings = {"custom_dts": {"key1": "pass1"}}
+        egg_filter = Filters.EggFilter('filter1', settings)
+
+        # Generate events that should pass
+        pass1 = Events.EggEvent(generate_egg({}))
+        # Test passing events
+        for e in [pass1]:
+            self.assertTrue(egg_filter.check_event(e))
 
 
 # Create a generic egg, overriding with an specific values

--- a/tests/filters/test_egg_filter.py
+++ b/tests/filters/test_egg_filter.py
@@ -31,7 +31,7 @@ class TestEggFilter(unittest.TestCase):
         # Test failing events
         for e in [fail1, fail2]:
             self.assertFalse(egg_filter.check_event(e))
-			
+
     def test_egg_dist(self):
         # Create the filters
         settings = {"min_dist": 200, "max_dist": 500}
@@ -96,6 +96,7 @@ class TestEggFilter(unittest.TestCase):
         for e in [fail1]:
             self.assertFalse(egg_filter.check_event(e))
 
+
 # Create a generic egg, overriding with an specific values
 def generate_egg(values):
     egg = {
@@ -111,6 +112,7 @@ def generate_egg(values):
     }
     egg.update(values)
     return egg
-	
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/filters/test_gym_filter.py
+++ b/tests/filters/test_gym_filter.py
@@ -53,16 +53,58 @@ class TestGymFilter(unittest.TestCase):
         for e in [fail1]:
             self.assertFalse(gym_filter.check_event(e))
 
-    def test_missing_info(self):
+    def test_missing_info1(self):
         # Create the filters
         settings = {"max_dist": "inf", "is_missing_info": True}
         gym_filter = Filters.GymFilter('filter1', settings)
 
         # Generate events that should pass
-        pass1 = Events.GymEvent(generate_gym({"distance": "Unknown"}))
+        pass1 = Events.GymEvent(generate_gym({"dist": "Unknown"}))
         # Test passing events
         for e in [pass1]:
             self.assertTrue(gym_filter.check_event(e))
+
+    def test_missing_info2(self):
+        # Create the filters
+        settings = {"max_dist": "inf", "is_missing_info": False}
+        gym_filter = Filters.GymFilter('filter1', settings)
+
+        # Generate events that should pass
+        pass1 = Events.GymEvent(generate_gym({}))
+        pass1.distance = 1000
+
+        # Test passing events
+        for e in [pass1]:
+            self.assertTrue(gym_filter.check_event(e))
+
+    def test_egg_distance(self):
+        # Create the filters
+        settings = {"max_dist": "2000", "min_dist": "400"}
+        gym_filter = Filters.GymFilter('filter1', settings)
+
+        # Generate events that should pass
+        pass1 = Events.GymEvent(generate_gym({}))
+        pass1.distance = 1000
+        pass2 = Events.GymEvent(generate_gym({}))
+        pass2.distance = 800
+        pass3 = Events.GymEvent(generate_gym({}))
+        pass3.distance = 600
+
+        # Test passing events
+        for e in [pass1]:
+            self.assertTrue(gym_filter.check_event(e))
+
+        # Generate events that should fail
+        fail1 = Events.GymEvent(generate_gym({}))
+        fail1.distance = 3000
+        fail2 = Events.GymEvent(generate_gym({}))
+        fail2.distance = 300
+        fail3 = Events.GymEvent(generate_gym({}))
+        fail3.distance = 0
+
+        # Test failing events
+        for e in [fail1, fail2, fail3]:
+            self.assertFalse(gym_filter.check_event(e))
 
     def test_custom_dts(self):
         # Create the filters

--- a/tests/filters/test_gym_filter.py
+++ b/tests/filters/test_gym_filter.py
@@ -32,7 +32,7 @@ class TestGymFilter(unittest.TestCase):
         # Test failing events
         for e in [fail1, fail2, fail3]:
             self.assertFalse(gym_filter.check_event(e))
-			
+
     def test_gym_team(self):
         # Create the filters
         settings = {"new_teams": [1, "2", "Instinct"]}
@@ -52,7 +52,8 @@ class TestGymFilter(unittest.TestCase):
         # Test failing events
         for e in [fail1]:
             self.assertFalse(gym_filter.check_event(e))		
-				
+
+			
 # Create a generic gym, overriding with an specific values
 def generate_generic_gym(values):
     gym = {

--- a/tests/filters/test_gym_filter.py
+++ b/tests/filters/test_gym_filter.py
@@ -55,11 +55,11 @@ class TestGymFilter(unittest.TestCase):
 
     def test_missing_info(self):
         # Create the filters
-        settings = {"missing_info": True}
+        settings = {"max_dist": "inf", "is_missing_info": True}
         gym_filter = Filters.GymFilter('filter1', settings)
 
         # Generate events that should pass
-        pass1 = Events.GymEvent(generate_gym({}))
+        pass1 = Events.GymEvent(generate_gym({"distance": "Unknown"}))
         # Test passing events
         for e in [pass1]:
             self.assertTrue(gym_filter.check_event(e))

--- a/tests/filters/test_gym_filter.py
+++ b/tests/filters/test_gym_filter.py
@@ -32,8 +32,27 @@ class TestGymFilter(unittest.TestCase):
         # Test failing events
         for e in [fail1, fail2, fail3]:
             self.assertFalse(gym_filter.check_event(e))
+			
+    def test_gym_team(self):
+        # Create the filters
+        settings = {"new_teams": [1, "2", "Instinct"]}
+        gym_filter = Filters.GymFilter('filter1', settings)
 
+        # Generate events that should pass
+        pass1 = Events.GymEvent(generate_generic_gym({"team": 1}))
+        pass2 = Events.GymEvent(generate_generic_gym({"team": 2}))
+        pass3 = Events.GymEvent(generate_generic_gym({"team": 3}))
+        # Test passing events
+        for e in [pass1, pass2, pass3]:
+            self.assertTrue(gym_filter.check_event(e))
 
+        # Generate events that should fail
+        fail1 = Events.GymEvent(generate_generic_gym({"team": 0}))
+
+        # Test failing events
+        for e in [fail1]:
+            self.assertFalse(gym_filter.check_event(e))		
+				
 # Create a generic gym, overriding with an specific values
 def generate_generic_gym(values):
     gym = {

--- a/tests/filters/test_gym_filter.py
+++ b/tests/filters/test_gym_filter.py
@@ -17,17 +17,17 @@ class TestGymFilter(unittest.TestCase):
         gym_filter = Filters.GymFilter('filter1', settings)
 
         # Generate events that should pass
-        pass1 = Events.GymEvent(generate_generic_gym({"name": "pass1"}))
-        pass2 = Events.GymEvent(generate_generic_gym({"name": "pass2"}))
-        pass3 = Events.GymEvent(generate_generic_gym({"name": "pass3"}))
+        pass1 = Events.GymEvent(generate_gym({"name": "pass1"}))
+        pass2 = Events.GymEvent(generate_gym({"name": "pass2"}))
+        pass3 = Events.GymEvent(generate_gym({"name": "pass3"}))
         # Test passing events
         for e in [pass1, pass2, pass3]:
             self.assertTrue(gym_filter.check_event(e))
 
         # Generate events that should fail
-        fail1 = Events.GymEvent(generate_generic_gym({"name": "fail1"}))
-        fail2 = Events.GymEvent(generate_generic_gym({"name": "failpass"}))
-        fail3 = Events.GymEvent(generate_generic_gym({"name": "passfail"}))
+        fail1 = Events.GymEvent(generate_gym({"name": "fail1"}))
+        fail2 = Events.GymEvent(generate_gym({"name": "failpass"}))
+        fail3 = Events.GymEvent(generate_gym({"name": "passfail"}))
 
         # Test failing events
         for e in [fail1, fail2, fail3]:
@@ -39,23 +39,45 @@ class TestGymFilter(unittest.TestCase):
         gym_filter = Filters.GymFilter('filter1', settings)
 
         # Generate events that should pass
-        pass1 = Events.GymEvent(generate_generic_gym({"team": 1}))
-        pass2 = Events.GymEvent(generate_generic_gym({"team": 2}))
-        pass3 = Events.GymEvent(generate_generic_gym({"team": 3}))
+        pass1 = Events.GymEvent(generate_gym({"team": 1}))
+        pass2 = Events.GymEvent(generate_gym({"team": 2}))
+        pass3 = Events.GymEvent(generate_gym({"team": 3}))
         # Test passing events
         for e in [pass1, pass2, pass3]:
             self.assertTrue(gym_filter.check_event(e))
 
         # Generate events that should fail
-        fail1 = Events.GymEvent(generate_generic_gym({"team": 0}))
+        fail1 = Events.GymEvent(generate_gym({"team": 0}))
 
         # Test failing events
         for e in [fail1]:
             self.assertFalse(gym_filter.check_event(e))
 
+    def test_missing_info(self):
+        # Create the filters
+        settings = {"missing_info": True}
+        gym_filter = Filters.GymFilter('filter1', settings)
+
+        # Generate events that should pass
+        pass1 = Events.GymEvent(generate_gym({}))
+        # Test passing events
+        for e in [pass1]:
+            self.assertTrue(gym_filter.check_event(e))
+
+    def test_custom_dts(self):
+        # Create the filters
+        settings = {"custom_dts": {"key1": "pass1"}}
+        gym_filter = Filters.GymFilter('filter1', settings)
+
+        # Generate events that should pass
+        pass1 = Events.GymEvent(generate_gym({}))
+        # Test passing events
+        for e in [pass1]:
+            self.assertTrue(gym_filter.check_event(e))
+
 
 # Create a generic gym, overriding with an specific values
-def generate_generic_gym(values):
+def generate_gym(values):
     gym = {
         "id": "OWNmOTFmMmM0YTY3NGQwYjg0Y2I1N2JlZjU4OWRkMTYuMTY=",
         "url": "???",

--- a/tests/filters/test_gym_filter.py
+++ b/tests/filters/test_gym_filter.py
@@ -51,9 +51,9 @@ class TestGymFilter(unittest.TestCase):
 
         # Test failing events
         for e in [fail1]:
-            self.assertFalse(gym_filter.check_event(e))		
+            self.assertFalse(gym_filter.check_event(e))
 
-			
+
 # Create a generic gym, overriding with an specific values
 def generate_generic_gym(values):
     gym = {

--- a/tests/filters/test_raid_filter.py
+++ b/tests/filters/test_raid_filter.py
@@ -140,17 +140,58 @@ class TestRaidFilter(unittest.TestCase):
         for e in [fail1]:
             self.assertFalse(raid_filter.check_event(e))
 
-    def test_missing_info(self):
+    def test_missing_info1(self):
         # Create the filters
         settings = {"max_dist": "inf", "is_missing_info": True}
         raid_filter = Filters.RaidFilter('filter1', settings)
 
         # Generate events that should pass
-        pass1 = Events.RaidEvent(generate_raid({"distance": "Unknown"}))
+        pass1 = Events.RaidEvent(generate_raid({"dist": "Unknown"}))
         # Test passing events
         for e in [pass1]:
             self.assertTrue(raid_filter.check_event(e))
 
+    def test_missing_info2(self):
+        # Create the filters
+        settings = {"max_dist": "inf", "is_missing_info": False}
+        raid_filter = Filters.RaidFilter('filter1', settings)
+
+        # Generate events that should pass
+        pass1 = Events.RaidEvent(generate_raid({}))
+        pass1.distance = 1000
+
+        # Test passing events
+        for e in [pass1]:
+            self.assertTrue(raid_filter.check_event(e))
+
+    def test_egg_distance(self):
+        # Create the filters
+        settings = {"max_dist": "2000", "min_dist": "400"}
+        raid_filter = Filters.RaidFilter('filter1', settings)
+
+        # Generate events that should pass
+        pass1 = Events.RaidEvent(generate_raid({}))
+        pass1.distance = 1000
+        pass2 = Events.RaidEvent(generate_raid({}))
+        pass2.distance = 800
+        pass3 = Events.RaidEvent(generate_raid({}))
+        pass3.distance = 600
+
+        # Test passing events
+        for e in [pass1]:
+            self.assertTrue(raid_filter.check_event(e))
+
+        # Generate events that should fail
+        fail1 = Events.RaidEvent(generate_raid({}))
+        fail1.distance = 3000
+        fail2 = Events.RaidEvent(generate_raid({}))
+        fail2.distance = 300
+        fail3 = Events.RaidEvent(generate_raid({}))
+        fail3.distance = 0
+
+        # Test failing events
+        for e in [fail1, fail2, fail3]:
+            self.assertFalse(raid_filter.check_event(e))
 
     def test_custom_dts(self):
         # Create the filters

--- a/tests/filters/test_raid_filter.py
+++ b/tests/filters/test_raid_filter.py
@@ -140,6 +140,7 @@ class TestRaidFilter(unittest.TestCase):
         for e in [fail1]:
             self.assertFalse(raid_filter.check_event(e))
 
+
 # Create a generic raid, overriding with an specific values
 def generate_raid(values):
     raid = {

--- a/tests/filters/test_raid_filter.py
+++ b/tests/filters/test_raid_filter.py
@@ -1,0 +1,164 @@
+import unittest
+import PokeAlarm.Filters as Filters
+import PokeAlarm.Events as Events
+
+
+class TestRaidFilter(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_monster_id(self):
+        # Create the filters
+        settings = {"monsters": [382, "383", "Rayquaza"]}
+        raid_filter = Filters.RaidFilter('filter1', settings)
+
+        # Generate events that should pass
+        pass1 = Events.RaidEvent(generate_raid({"pokemon_id": 382}))
+        pass2 = Events.RaidEvent(generate_raid({"pokemon_id": 383}))
+        pass3 = Events.RaidEvent(generate_raid({"pokemon_id": 384}))
+        # Test passing events
+        for e in [pass1, pass2, pass3]:
+            self.assertTrue(raid_filter.check_event(e))
+
+        # Generate events that should fail
+        fail1 = Events.RaidEvent(generate_raid({"pokemon_id": 20}))
+        fail2 = Events.RaidEvent(generate_raid({"pokemon_id": 150}))
+        fail3 = Events.RaidEvent(generate_raid({"pokemon_id": 301}))
+
+        # Test failing events
+        for e in [fail1, fail2, fail3]:
+            self.assertFalse(raid_filter.check_event(e))
+
+    def test_quick_move(self):
+        # Create the filters
+        settings = {"quick_moves": [225, "88", "Present"]}
+        raid_filter = Filters.RaidFilter('filter1', settings)
+
+        # Generate events that should pass
+        pass1 = Events.RaidEvent(generate_raid({"move_1": 225}))
+        pass2 = Events.RaidEvent(generate_raid({"move_1": 88}))
+        pass3 = Events.RaidEvent(generate_raid({"move_1": 291}))
+        # Test passing events
+        for e in [pass1, pass2, pass3]:
+            self.assertTrue(raid_filter.check_event(e))
+
+        # Generate events that should fail
+        fail1 = Events.RaidEvent(generate_raid({"move_1": 200}))
+        fail2 = Events.RaidEvent(generate_raid({"move_1": 201}))
+        fail3 = Events.RaidEvent(generate_raid({"move_1": 202}))
+
+        # Test failing events
+        for e in [fail1, fail2, fail3]:
+            self.assertFalse(raid_filter.check_event(e))
+
+    def test_charge_move(self):
+        # Create the filters
+        settings = {"charge_moves": [283, "14", "Solar Beam"]}
+        raid_filter = Filters.RaidFilter('filter1', settings)
+
+        # Generate events that should pass
+        pass1 = Events.RaidEvent(generate_raid({"move_2": 283}))
+        pass2 = Events.RaidEvent(generate_raid({"move_2": 14}))
+        pass3 = Events.RaidEvent(generate_raid({"move_2": 116}))
+        # Test passing events
+        for e in [pass1, pass2, pass3]:
+            self.assertTrue(raid_filter.check_event(e))
+
+        # Generate events that should fail
+        fail1 = Events.RaidEvent(generate_raid({"move_2": 200}))
+        fail2 = Events.RaidEvent(generate_raid({"move_2": 201}))
+        fail3 = Events.RaidEvent(generate_raid({"move_2": 202}))
+
+        # Test failing events
+        for e in [fail1, fail2, fail3]:
+            self.assertFalse(raid_filter.check_event(e))
+
+    def test_raid_lvl(self):
+        # Create the filters
+        settings = {"min_raid_lvl": 3, "max_raid_lvl": 5}
+        raid_filter = Filters.RaidFilter('filter1', settings)
+
+        # Generate events that should pass
+        pass1 = Events.RaidEvent(generate_raid({"level": 3}))
+        pass2 = Events.RaidEvent(generate_raid({"level": 4}))
+        pass3 = Events.RaidEvent(generate_raid({"level": 5}))
+        # Test passing events
+        for e in [pass1, pass2, pass3]:
+            self.assertTrue(raid_filter.check_event(e))
+
+        # Generate events that should fail
+        fail1 = Events.RaidEvent(generate_raid({"level": 1}))
+        fail2 = Events.RaidEvent(generate_raid({"level": 2}))
+
+        # Test failing events
+        for e in [fail1, fail2]:
+            self.assertFalse(raid_filter.check_event(e))
+
+    def test_gym_names(self):
+        # Create the filters
+        settings = {"gym_name_matches": ["pass.\Z"]}
+        raid_filter = Filters.RaidFilter('filter1', settings)
+
+        # Generate events that should pass
+        pass1 = Events.RaidEvent(generate_raid({"name": "pass1"}))
+        pass2 = Events.RaidEvent(generate_raid({"name": "pass2"}))
+        pass3 = Events.RaidEvent(generate_raid({"name": "pass3"}))
+        # Test passing events
+        for e in [pass1, pass2, pass3]:
+            self.assertTrue(raid_filter.check_event(e))
+
+        # Generate events that should fail
+        fail1 = Events.RaidEvent(generate_raid({"name": "fail1"}))
+        fail2 = Events.RaidEvent(generate_raid({"name": "failpass"}))
+        fail3 = Events.RaidEvent(generate_raid({"name": "passfail"}))
+
+        # Test failing events
+        for e in [fail1, fail2, fail3]:
+            self.assertFalse(raid_filter.check_event(e))
+
+    def test_current_team(self):
+        # Create the filters
+        settings = {"current_teams": [1, "2", "Instinct"]}
+        raid_filter = Filters.RaidFilter('filter1', settings)
+
+        # Generate events that should pass
+        pass1 = Events.RaidEvent(generate_raid({"team": 1}))
+        pass2 = Events.RaidEvent(generate_raid({"team": 2}))
+        pass3 = Events.RaidEvent(generate_raid({"team": 3}))
+        # Test passing events
+        for e in [pass1, pass2, pass3]:
+            self.assertTrue(raid_filter.check_event(e))
+
+        # Generate events that should fail
+        fail1 = Events.RaidEvent(generate_raid({"team": 0}))
+
+        # Test failing events
+        for e in [fail1]:
+            self.assertFalse(raid_filter.check_event(e))
+
+# Create a generic raid, overriding with an specific values
+def generate_raid(values):
+    raid = {
+        "gym_id": "OWNmOTFmMmM0YTY3NGQwYjg0Y2I1N2JlZjU4OWRkMTYuMTY=",
+        "url": "???",
+        "name": "unknown",
+        "description": "???",
+        "pokemon_id": 150,
+        "cp": 12345,
+        "move_1": 123,
+        "move_2": 123,
+        "start": 1499244052,
+        "end": 1499246052,
+        "level": 5,
+        "latitude": 37.7876146,
+        "longitude": -122.390624
+    }
+    raid.update(values)
+    return raid
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/filters/test_raid_filter.py
+++ b/tests/filters/test_raid_filter.py
@@ -161,5 +161,6 @@ def generate_raid(values):
     raid.update(values)
     return raid
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/filters/test_raid_filter.py
+++ b/tests/filters/test_raid_filter.py
@@ -79,20 +79,20 @@ class TestRaidFilter(unittest.TestCase):
 
     def test_raid_lvl(self):
         # Create the filters
-        settings = {"min_raid_lvl": 3, "max_raid_lvl": 5}
+        settings = {"min_raid_lvl": 2, "max_raid_lvl": 4}
         raid_filter = Filters.RaidFilter('filter1', settings)
 
         # Generate events that should pass
-        pass1 = Events.RaidEvent(generate_raid({"level": 3}))
-        pass2 = Events.RaidEvent(generate_raid({"level": 4}))
-        pass3 = Events.RaidEvent(generate_raid({"level": 5}))
+        pass1 = Events.RaidEvent(generate_raid({"level": 2}))
+        pass2 = Events.RaidEvent(generate_raid({"level": 3}))
+        pass3 = Events.RaidEvent(generate_raid({"level": 4}))
         # Test passing events
         for e in [pass1, pass2, pass3]:
             self.assertTrue(raid_filter.check_event(e))
 
         # Generate events that should fail
         fail1 = Events.RaidEvent(generate_raid({"level": 1}))
-        fail2 = Events.RaidEvent(generate_raid({"level": 2}))
+        fail2 = Events.RaidEvent(generate_raid({"level": 5}))
 
         # Test failing events
         for e in [fail1, fail2]:
@@ -140,13 +140,36 @@ class TestRaidFilter(unittest.TestCase):
         for e in [fail1]:
             self.assertFalse(raid_filter.check_event(e))
 
+    def test_missing_info(self):
+        # Create the filters
+        settings = {"missing_info": True}
+        raid_filter = Filters.RaidFilter('filter1', settings)
+
+        # Generate events that should pass
+        pass1 = Events.RaidEvent(generate_raid({}))
+        # Test passing events
+        for e in [pass1]:
+            self.assertTrue(raid_filter.check_event(e))
+
+
+    def test_custom_dts(self):
+        # Create the filters
+        settings = {"custom_dts": {"key1": "pass1"}}
+        raid_filter = Filters.RaidFilter('filter1', settings)
+
+        # Generate events that should pass
+        pass1 = Events.RaidEvent(generate_raid({}))
+        # Test passing events
+        for e in [pass1]:
+            self.assertTrue(raid_filter.check_event(e))
+
 
 # Create a generic raid, overriding with an specific values
 def generate_raid(values):
     raid = {
         "gym_id": "OWNmOTFmMmM0YTY3NGQwYjg0Y2I1N2JlZjU4OWRkMTYuMTY=",
         "url": "???",
-        "name": "unknown",
+        "name": "Unknown",
         "description": "???",
         "pokemon_id": 150,
         "cp": 12345,

--- a/tests/filters/test_raid_filter.py
+++ b/tests/filters/test_raid_filter.py
@@ -142,11 +142,11 @@ class TestRaidFilter(unittest.TestCase):
 
     def test_missing_info(self):
         # Create the filters
-        settings = {"missing_info": True}
+        settings = {"max_dist": "inf", "is_missing_info": True}
         raid_filter = Filters.RaidFilter('filter1', settings)
 
         # Generate events that should pass
-        pass1 = Events.RaidEvent(generate_raid({}))
+        pass1 = Events.RaidEvent(generate_raid({"distance": "Unknown"}))
         # Test passing events
         for e in [pass1]:
             self.assertTrue(raid_filter.check_event(e))


### PR DESCRIPTION
<!--       PULL REQUESTS CREATED NOT USING ONE OF THE BELOW         --->
<!--      ISSUE TEMPLATES WILL BE CLOSED WITHOUT ANY RESPONSE       --->
<!--       PULL REQUESTS CREATED NOT USING ONE OF THE BELOW         --->
<!--      ISSUE TEMPLATES WILL BE CLOSED WITHOUT ANY RESPONSE       --->
<!--       PULL REQUESTS CREATED NOT USING ONE OF THE BELOW         --->
<!--      ISSUE TEMPLATES WILL BE CLOSED WITHOUT ANY RESPONSE       --->
<!--       PULL REQUESTS CREATED NOT USING ONE OF THE BELOW         --->
<!--      ISSUE TEMPLATES WILL BE CLOSED WITHOUT ANY RESPONSE       --->


<!--
 Please make all PRs to the dev branch. The dev branch will be
 periodically pulled into the master branch. This allows time for
 the changes and documentation to be tested before being exposed to
 a wider population.
--->

## Description
Unit testing for Egg, Raid and Gym Filters.  Also fixes issue with`move_id` filter for raids. 

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
Testing the new filter changes

## How Has This Been Tested?
Locally using python unit testing

## Screenshots (if appropriate):
N/A

## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change to https://github.com/RocketMap/PokeAlarmWiki.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [ ] This change requires an update to the Wiki.
- [x] This change does not require an update to the Wiki.


## Checklist
- [x] This change follows the code style of this project.
- [x] This change only changes what is necessary to the feature.
