### PR TITLE
Pushing slots_available/guard_count DTS + min/max_slots Filters

### DIFF
--- a/PokeAlarm/Events/GymEvent.py
+++ b/PokeAlarm/Events/GymEvent.py
@@ -35,6 +35,14 @@ class GymEvent(BaseEvent):
         self.gym_image = check_for_none(
             str, data.get('url'), Unknown.REGULAR)
 
+        # Gym Guards
+        self.slots_available = check_for_none(
+            int, data.get('slots_available'), Unknown.TINY)
+        self.guard_count = (
+            (6 - self.slots_available)
+            if Unknown.is_not(self.slots_available)
+            else Unknown.TINY),
+
         self.name = self.gym_id
         self.geofence = Unknown.REGULAR
         self.custom_dts = {}
@@ -71,5 +79,9 @@ class GymEvent(BaseEvent):
             'gym_name': self.gym_name,
             'gym_description': self.gym_description,
             'gym_image': self.gym_image,
+
+            # Guards
+            'slots_available': self.slots_available,
+            'guard_count': self.guard_count,
         })
         return dts

--- a/PokeAlarm/Filters/GymFilter.py
+++ b/PokeAlarm/Filters/GymFilter.py
@@ -38,6 +38,16 @@ class GymFilter(BaseFilter):
             limit=BaseFilter.parse_as_set(
                 re.compile, 'gym_name_matches', data))
 
+        # Slots Available
+        self.min_slots = self.evaluate_attribute(
+            # f.min_slots <= r.slots_available
+            event_attribute='slots_available', eval_func=operator.le,
+            limit=BaseFilter.parse_as_type(int, 'min_slots', data))
+        self.max_slots = self.evaluate_attribute(
+            # f.max_slots >= r.slots_available
+            event_attribute='slots_available', eval_func=operator.ge,
+            limit=BaseFilter.parse_as_type(int, 'max_slots', data))
+
         # Geofences
         self.geofences = BaseFilter.parse_as_set(str, 'geofences', data)
 

--- a/tests/filters/test_gym_filter.py
+++ b/tests/filters/test_gym_filter.py
@@ -33,6 +33,28 @@ class TestGymFilter(unittest.TestCase):
         for e in [fail1, fail2, fail3]:
             self.assertFalse(gym_filter.check_event(e))
 
+    def test_gym_guards(self):
+        # Create the filters
+        settings = {"min_slots": 2, "max_slots": 4}
+        gym_filter = Filters.GymFilter('filter1', settings)
+
+        # Generate events that should pass
+        pass1 = Events.GymEvent(generate_gym({"slots_available": 2}))
+        pass2 = Events.GymEvent(generate_gym({"slots_available": 3}))
+        pass3 = Events.GymEvent(generate_gym({"slots_available": 4}))
+        # Test passing events
+        for e in [pass1, pass2, pass3]:
+            self.assertTrue(gym_filter.check_event(e))
+
+        # Generate events that should fail
+        fail1 = Events.GymEvent(generate_gym({"slots_available": 0}))
+        fail2 = Events.GymEvent(generate_gym({"slots_available": 1}))
+        fail3 = Events.GymEvent(generate_gym({"slots_available": 5}))
+
+        # Test failing events
+        for e in [fail1, fail2, fail3]:
+            self.assertFalse(gym_filter.check_event(e))
+
     def test_gym_team(self):
         # Create the filters
         settings = {"new_teams": [1, "2", "Instinct"]}


### PR DESCRIPTION
<!--       PULL REQUESTS CREATED NOT USING ONE OF THE BELOW         --->
<!--      ISSUE TEMPLATES WILL BE CLOSED WITHOUT ANY RESPONSE       --->
<!--       PULL REQUESTS CREATED NOT USING ONE OF THE BELOW         --->
<!--      ISSUE TEMPLATES WILL BE CLOSED WITHOUT ANY RESPONSE       --->
<!--       PULL REQUESTS CREATED NOT USING ONE OF THE BELOW         --->
<!--      ISSUE TEMPLATES WILL BE CLOSED WITHOUT ANY RESPONSE       --->
<!--       PULL REQUESTS CREATED NOT USING ONE OF THE BELOW         --->
<!--      ISSUE TEMPLATES WILL BE CLOSED WITHOUT ANY RESPONSE       --->


<!--
 Please make all PRs to the dev branch. The dev branch will be
 periodically pulled into the master branch. This allows time for
 the changes and documentation to be tested before being exposed to
 a wider population.
--->

## Description
Adds support for the `slots_available` data sent by RocketMap.  Also adds `<slots_available>` and `<guard_count>` DTS fields for Gym Alerts

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
Allows alerting on how many slots are available in a gym and how many guards it currently has.  Can be used to help teams coordinate gym attacks and defense. 

## How Has This Been Tested?
Tested locally using the webhook tester. 

## Screenshots (if appropriate):
![2017-11-22 18_26_51- mod-chat - discord](https://user-images.githubusercontent.com/3013565/33154658-dbb2c748-cfb7-11e7-81bc-d350c054560b.png)

## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change to https://github.com/RocketMap/PokeAlarmWiki.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [x] This change requires an update to the Wiki.
- [ ] This change does not require an update to the Wiki.


## Checklist
- [x] This change follows the code style of this project.
- [x] This change only changes what is necessary to the feature.

  