### PR TITLE
 Gym_Name not working for raid notifications.

### DIFF
--- a/PokeAlarm/Events/RaidEvent.py
+++ b/PokeAlarm/Events/RaidEvent.py
@@ -18,7 +18,7 @@ class RaidEvent(BaseEvent):
         check_for_none = BaseEvent.check_for_none
 
         # Identification
-        self.gym_id = data.get('gym_id')
+        self.gym_id = data.get('gym_id', data.get('id'))
 
         # Time Remaining
         self.raid_end = datetime.utcfromtimestamp(


### PR DESCRIPTION

## Description
Adding the ", data.get('id')" fixes the issue and allows the user to post gym_name successfully.


## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
Allows users to post gym name on Egg and Raid notifications.

## How Has This Been Tested?
Tested locally through Webhook_test and in through local Alarm.


## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change to https://github.com/RocketMap/PokeAlarmWiki.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [ ] This change requires an update to the Wiki.
- [X] This change does not require an update to the Wiki.


## Checklist
- [X] This change follows the code style of this project.
- [ ] This change only changes what is necessary to the feature.
