### PR TITLE
Manager: Do not stop checking filters after first match

### DIFF
--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -485,31 +485,31 @@ class Manager(object):
         passed = False
         for name, f in self.__mon_filters.iteritems():
             passed = f.check_event(mon) and self.check_geofences(f, mon)
-            if passed:  # Stop checking
+            if passed:
                 mon.custom_dts = f.custom_dts
-                break
+
+                # Generate the DTS for the event
+                dts = mon.generate_dts(self.__locale)
+
+                if self.__loc_service:
+                    self.__loc_service.add_optional_arguments(
+                        self.__location, [mon.lat, mon.lng], dts)
+
+                if self.__quiet is False:
+                    log.info("{} monster notification has been triggered!"
+                        .format(mon.name))
+
+                threads = []
+                # Spawn notifications in threads so they can work in background
+                for alarm in self.__alarms:
+                    threads.append(gevent.spawn(alarm.pokemon_alert, dts))
+                gevent.sleep(0)  # explict context yield
+
+                for thread in threads:
+                    thread.join()
+
         if not passed:  # Monster was rejected by all filters
             return
-
-        # Generate the DTS for the event
-        dts = mon.generate_dts(self.__locale)
-
-        if self.__loc_service:
-            self.__loc_service.add_optional_arguments(
-                self.__location, [mon.lat, mon.lng], dts)
-
-        if self.__quiet is False:
-            log.info("{} monster notification has been triggered!".format(
-                mon.name))
-
-        threads = []
-        # Spawn notifications in threads so they can work in background
-        for alarm in self.__alarms:
-            threads.append(gevent.spawn(alarm.pokemon_alert, dts))
-        gevent.sleep(0)  # explict context yield
-
-        for thread in threads:
-            thread.join()
 
     def process_stop(self, stop):
         # type: (Events.StopEvent) -> None
@@ -545,30 +545,30 @@ class Manager(object):
         passed = True
         for name, f in self.__stop_filters.iteritems():
             passed = f.check_event(stop) and self.check_geofences(f, stop)
-            if passed:  # Stop checking
+            if passed: 
                 stop.custom_dts = f.custom_dts
-                break
-        if not passed:  # Stop was rejected by all filters
+
+                # Generate the DTS for the event
+                dts = stop.generate_dts(self.__locale)
+                if self.__loc_service:
+                    self.__loc_service.add_optional_arguments(
+                        self.__location, [stop.lat, stop.lng], dts)
+
+                if self.__quiet is False:
+                    log.info("Stop {} notification has been triggered!".format(
+                        stop.name))
+
+                threads = []
+                # Spawn notifications in threads so they can work in background
+                for alarm in self.__alarms:
+                    threads.append(gevent.spawn(alarm.pokestop_alert, dts))
+                gevent.sleep(0)  # explict context yield
+
+                for thread in threads:
+                    thread.join()
+
+        if not passed:
             return
-
-        # Generate the DTS for the event
-        dts = stop.generate_dts(self.__locale)
-        if self.__loc_service:
-            self.__loc_service.add_optional_arguments(
-                self.__location, [stop.lat, stop.lng], dts)
-
-        if self.__quiet is False:
-            log.info("Stop {} notification has been triggered!".format(
-                stop.name))
-
-        threads = []
-        # Spawn notifications in threads so they can work in background
-        for alarm in self.__alarms:
-            threads.append(gevent.spawn(alarm.pokestop_alert, dts))
-        gevent.sleep(0)  # explict context yield
-
-        for thread in threads:
-            thread.join()
 
     def process_gym(self, gym):
         # type: (Events.GymEvent) -> None
@@ -616,29 +616,31 @@ class Manager(object):
             passed = f.check_event(gym) and self.check_geofences(f, gym)
             if passed:  # Stop checking
                 gym.custom_dts = f.custom_dts
-                break
+
+                # Generate the DTS for the event
+                dts = gym.generate_dts(self.__locale)
+                #update gym info
+                dts.update(self.__cache.get_gym_info(gym.gym_id))
+                if self.__loc_service:
+                    self.__loc_service.add_optional_arguments(
+                        self.__location, [gym.lat, gym.lng], dts)
+
+                if self.__quiet is False:
+                    log.info(
+                        "{} gym notification has been triggered!"
+                        .format(gym.name))
+
+                threads = []
+                # Spawn notifications in threads so they can work in background
+                for alarm in self.__alarms:
+                    threads.append(gevent.spawn(alarm.gym_alert, dts))
+                gevent.sleep(0)  # explict context yield
+
+                for thread in threads:
+                    thread.join()
+
         if not passed:  # Gym was rejected by all filters
             return
-
-        # Generate the DTS for the event
-        dts = gym.generate_dts(self.__locale)
-        dts.update(self.__cache.get_gym_info(gym.gym_id))  # update gym info
-        if self.__loc_service:
-            self.__loc_service.add_optional_arguments(
-                self.__location, [gym.lat, gym.lng], dts)
-
-        if self.__quiet is False:
-            log.info(
-                "{} gym notification has been triggered!".format(gym.name))
-
-        threads = []
-        # Spawn notifications in threads so they can work in background
-        for alarm in self.__alarms:
-            threads.append(gevent.spawn(alarm.gym_alert, dts))
-        gevent.sleep(0)  # explict context yield
-
-        for thread in threads:
-            thread.join()
 
     def process_egg(self, egg):
         # type: (Events.EggEvent) -> None
@@ -687,29 +689,30 @@ class Manager(object):
             passed = f.check_event(egg) and self.check_geofences(f, egg)
             if passed:  # Stop checking
                 egg.custom_dts = f.custom_dts
-                break
+
+                # Generate the DTS for the event
+                dts = egg.generate_dts(self.__locale)
+                # update gym info
+                dts.update(self.__cache.get_gym_info(egg.gym_id))
+                if self.__loc_service:
+                    self.__loc_service.add_optional_arguments(
+                        self.__location, [egg.lat, egg.lng], dts)
+
+                if self.__quiet is False:
+                    log.info("{} egg notification has been triggered!"
+                        .format(egg.name))
+
+                threads = []
+                # Spawn notifications in threads so they can work in background
+                for alarm in self.__alarms:
+                    threads.append(gevent.spawn(alarm.raid_egg_alert, dts))
+                gevent.sleep(0)  # explict context yield
+
+                for thread in threads:
+                    thread.join()
+
         if not passed:  # Egg was rejected by all filters
             return
-
-        # Generate the DTS for the event
-        dts = egg.generate_dts(self.__locale)
-        dts.update(self.__cache.get_gym_info(egg.gym_id))  # update gym info
-        if self.__loc_service:
-            self.__loc_service.add_optional_arguments(
-                self.__location, [egg.lat, egg.lng], dts)
-
-        if self.__quiet is False:
-            log.info(
-                "{} egg notification has been triggered!".format(egg.name))
-
-        threads = []
-        # Spawn notifications in threads so they can work in background
-        for alarm in self.__alarms:
-            threads.append(gevent.spawn(alarm.raid_egg_alert, dts))
-        gevent.sleep(0)  # explict context yield
-
-        for thread in threads:
-            thread.join()
 
     def process_raid(self, raid):
         # type: (Events.RaidEvent) -> None
@@ -758,29 +761,30 @@ class Manager(object):
             passed = f.check_event(raid) and self.check_geofences(f, raid)
             if passed:  # Stop checking
                 raid.custom_dts = f.custom_dts
-                break
+
+                # Generate the DTS for the event
+                dts = raid.generate_dts(self.__locale)
+                # update gym info
+                dts.update(self.__cache.get_gym_info(raid.gym_id))
+                if self.__loc_service:
+                    self.__loc_service.add_optional_arguments(
+                        self.__location, [raid.lat, raid.lng], dts)
+
+                if self.__quiet is False:
+                    log.info("{} raid notification has been triggered!"
+                        .format(raid.name))
+
+                threads = []
+                # Spawn notifications in threads so they can work in background
+                for alarm in self.__alarms:
+                    threads.append(gevent.spawn(alarm.raid_alert, dts))
+                gevent.sleep(0)  # explict context yield
+
+                for thread in threads:
+                    thread.join()
+
         if not passed:  # Raid was rejected by all filters
             return
-
-        # Generate the DTS for the event
-        dts = raid.generate_dts(self.__locale)
-        dts.update(self.__cache.get_gym_info(raid.gym_id))  # update gym info
-        if self.__loc_service:
-            self.__loc_service.add_optional_arguments(
-                self.__location, [raid.lat, raid.lng], dts)
-
-        if self.__quiet is False:
-            log.info(
-                "{} raid notification has been triggered!".format(raid.name))
-
-        threads = []
-        # Spawn notifications in threads so they can work in background
-        for alarm in self.__alarms:
-            threads.append(gevent.spawn(alarm.raid_alert, dts))
-        gevent.sleep(0)  # explict context yield
-
-        for thread in threads:
-            thread.join()
 
     # Check to see if a notification is within the given range
     def check_geofences(self, f, e):

--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -497,7 +497,7 @@ class Manager(object):
 
                 if self.__quiet is False:
                     log.info("{} monster notification has been triggered!"
-                        .format(mon.name))
+                             .format(mon.name))
 
                 threads = []
                 # Spawn notifications in threads so they can work in background
@@ -545,7 +545,7 @@ class Manager(object):
         passed = True
         for name, f in self.__stop_filters.iteritems():
             passed = f.check_event(stop) and self.check_geofences(f, stop)
-            if passed: 
+            if passed:
                 stop.custom_dts = f.custom_dts
 
                 # Generate the DTS for the event
@@ -619,7 +619,7 @@ class Manager(object):
 
                 # Generate the DTS for the event
                 dts = gym.generate_dts(self.__locale)
-                #update gym info
+                # update gym info
                 dts.update(self.__cache.get_gym_info(gym.gym_id))
                 if self.__loc_service:
                     self.__loc_service.add_optional_arguments(
@@ -700,7 +700,7 @@ class Manager(object):
 
                 if self.__quiet is False:
                     log.info("{} egg notification has been triggered!"
-                        .format(egg.name))
+                             .format(egg.name))
 
                 threads = []
                 # Spawn notifications in threads so they can work in background
@@ -772,7 +772,7 @@ class Manager(object):
 
                 if self.__quiet is False:
                     log.info("{} raid notification has been triggered!"
-                        .format(raid.name))
+                             .format(raid.name))
 
                 threads = []
                 # Spawn notifications in threads so they can work in background


### PR DESCRIPTION
<!--       PULL REQUESTS CREATED NOT USING ONE OF THE BELOW         --->
<!--      ISSUE TEMPLATES WILL BE CLOSED WITHOUT ANY RESPONSE       --->
<!--       PULL REQUESTS CREATED NOT USING ONE OF THE BELOW         --->
<!--      ISSUE TEMPLATES WILL BE CLOSED WITHOUT ANY RESPONSE       --->
<!--       PULL REQUESTS CREATED NOT USING ONE OF THE BELOW         --->
<!--      ISSUE TEMPLATES WILL BE CLOSED WITHOUT ANY RESPONSE       --->
<!--       PULL REQUESTS CREATED NOT USING ONE OF THE BELOW         --->
<!--      ISSUE TEMPLATES WILL BE CLOSED WITHOUT ANY RESPONSE       --->


<!--
 Please make all PRs to the dev branch. The dev branch will be
 periodically pulled into the master branch. This allows time for
 the changes and documentation to be tested before being exposed to
 a wider population.
--->

## Description
Applying this PR will enable PokeAlarm to match multiple filters on a single event. 

I discussed it with @billyjbryant already who explained that this change breaks the FIFO idea for filters, which was introduced to reduce memory footprint. It will also change behavior with existing configurations: Users might have set up their filters with the idea in mind that only the first match will be processed, leading to unexpected additional messages after this change. However, he encouraged me to submit the PR for discussion.

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (would cause existing functionality to change)

## Motivation and Context
I'm offering individualized Pokemon alarms on a per-user basis (through Telegram). Considering every single user might want to be informed about a wild Tyranitar, I'm forced to use a dedicated manager for every user, or only the lucky one to be the first in the filters file would be notified. At 50 users, I saw a total memory footprint of 650MB.

After applying this change, I can process all individual users through one single manager. The memory footprint now settles at 55 to 60MB. For me, the ability to reduce from 50 to 1 manager significantly outweighs the memory footprint reduction from application of the FIFO principle.

Another example would be raid channels with overlapping or layered areas. Let's say a discord server would have separate "New York" and "Lower Manhattan" channels. A raid in Lower Manhattan should  show up in both of these channels, so it would need to continue checking further filters after matching against the first one.

## How Has This Been Tested?
I've been using this along with https://github.com/PokeAlarm/PokeAlarm/pull/554 on my production environment serving 50+ individual users and 5 public channels and did not encounter any issues so far.

## Screenshots (if appropriate):


## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change to https://github.com/RocketMap/PokeAlarmWiki.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [x] This change requires an update to the Wiki.
- [ ] This change does not require an update to the Wiki.


## Checklist
- [x] This change follows the code style of this project.
- [x] This change only changes what is necessary to the feature.
