### PR TITLE
Performance fixes. 

### DIFF
--- a/PokeAlarm/Events/BaseEvent.py
+++ b/PokeAlarm/Events/BaseEvent.py
@@ -18,7 +18,7 @@ class BaseEvent(object):
         # Create an id for this event to be recognized as
         self.id = time.time()
 
-    def generate_dts(self, locale):
+    def generate_dts(self, locale, timezone):
         """ Return a dict with all the DTS for this event. """
         raise NotImplementedError("This is an abstract method.")
 

--- a/PokeAlarm/Events/BaseEvent.py
+++ b/PokeAlarm/Events/BaseEvent.py
@@ -18,7 +18,7 @@ class BaseEvent(object):
         # Create an id for this event to be recognized as
         self.id = time.time()
 
-    def generate_dts(self, locale, timezone):
+    def generate_dts(self, locale, timezone, units):
         """ Return a dict with all the DTS for this event. """
         raise NotImplementedError("This is an abstract method.")
 

--- a/PokeAlarm/Events/EggEvent.py
+++ b/PokeAlarm/Events/EggEvent.py
@@ -50,7 +50,7 @@ class EggEvent(BaseEvent):
         self.geofence = Unknown.REGULAR
         self.custom_dts = {}
 
-    def generate_dts(self, locale, timezone):
+    def generate_dts(self, locale, timezone, units):
         """ Return a dict with all the DTS for this event. """
         hatch_time = get_time_as_str(self.hatch_time)
         raid_end_time = get_time_as_str(self.raid_end, timezone)
@@ -73,8 +73,8 @@ class EggEvent(BaseEvent):
             'lat_5': "{:.5f}".format(self.lat),
             'lng_5': "{:.5f}".format(self.lng),
             'distance': (
-                get_dist_as_str(self.distance) if Unknown.is_not(self.distance)
-                else Unknown.SMALL),
+                get_dist_as_str(self.distance, units)
+                if Unknown.is_not(self.distance) else Unknown.SMALL),
             'direction': self.direction,
             'gmaps': get_gmaps_link(self.lat, self.lng),
             'applemaps': get_applemaps_link(self.lat, self.lng),

--- a/PokeAlarm/Events/EggEvent.py
+++ b/PokeAlarm/Events/EggEvent.py
@@ -50,10 +50,10 @@ class EggEvent(BaseEvent):
         self.geofence = Unknown.REGULAR
         self.custom_dts = {}
 
-    def generate_dts(self, locale):
+    def generate_dts(self, locale, timezone):
         """ Return a dict with all the DTS for this event. """
         hatch_time = get_time_as_str(self.hatch_time)
-        raid_end_time = get_time_as_str(self.raid_end)
+        raid_end_time = get_time_as_str(self.raid_end, timezone)
         dts = self.custom_dts.copy()
         dts.update({
             # Identification

--- a/PokeAlarm/Events/GymEvent.py
+++ b/PokeAlarm/Events/GymEvent.py
@@ -47,7 +47,7 @@ class GymEvent(BaseEvent):
         self.geofence = Unknown.REGULAR
         self.custom_dts = {}
 
-    def generate_dts(self, locale, timezone):
+    def generate_dts(self, locale, timezone, units):
         """ Return a dict with all the DTS for this event. """
         dts = self.custom_dts.copy()
         dts.update({
@@ -60,8 +60,8 @@ class GymEvent(BaseEvent):
             'lat_5': "{:.5f}".format(self.lat),
             'lng_5': "{:.5f}".format(self.lng),
             'distance': (
-                get_dist_as_str(self.distance) if Unknown.is_not(self.distance)
-                else Unknown.SMALL),
+                get_dist_as_str(self.distance, units)
+                if Unknown.is_not(self.distance) else Unknown.SMALL),
             'direction': self.direction,
             'gmaps': get_gmaps_link(self.lat, self.lng),
             'applemaps': get_applemaps_link(self.lat, self.lng),

--- a/PokeAlarm/Events/GymEvent.py
+++ b/PokeAlarm/Events/GymEvent.py
@@ -47,7 +47,7 @@ class GymEvent(BaseEvent):
         self.geofence = Unknown.REGULAR
         self.custom_dts = {}
 
-    def generate_dts(self, locale):
+    def generate_dts(self, locale, timezone):
         """ Return a dict with all the DTS for this event. """
         dts = self.custom_dts.copy()
         dts.update({

--- a/PokeAlarm/Events/MonEvent.py
+++ b/PokeAlarm/Events/MonEvent.py
@@ -90,9 +90,9 @@ class MonEvent(BaseEvent):
         self.geofence = Unknown.REGULAR
         self.custom_dts = {}
 
-    def generate_dts(self, locale):
+    def generate_dts(self, locale, timezone):
         """ Return a dict with all the DTS for this event. """
-        time = get_time_as_str(self.disappear_time)
+        time = get_time_as_str(self.disappear_time, timezone)
         form_name = locale.get_form_name(self.monster_id, self.form_id)
         dts = self.custom_dts.copy()
         dts.update({

--- a/PokeAlarm/Events/MonEvent.py
+++ b/PokeAlarm/Events/MonEvent.py
@@ -90,7 +90,7 @@ class MonEvent(BaseEvent):
         self.geofence = Unknown.REGULAR
         self.custom_dts = {}
 
-    def generate_dts(self, locale, timezone):
+    def generate_dts(self, locale, timezone, units):
         """ Return a dict with all the DTS for this event. """
         time = get_time_as_str(self.disappear_time, timezone)
         form_name = locale.get_form_name(self.monster_id, self.form_id)
@@ -118,8 +118,8 @@ class MonEvent(BaseEvent):
             'lat_5': "{:.5f}".format(self.lat),
             'lng_5': "{:.5f}".format(self.lng),
             'distance': (
-                get_dist_as_str(self.distance) if Unknown.is_not(self.distance)
-                else Unknown.SMALL),
+                get_dist_as_str(self.distance, units)
+                if Unknown.is_not(self.distance) else Unknown.SMALL),
             'direction': self.direction,
             'gmaps': get_gmaps_link(self.lat, self.lng),
             'applemaps': get_applemaps_link(self.lat, self.lng),

--- a/PokeAlarm/Events/RaidEvent.py
+++ b/PokeAlarm/Events/RaidEvent.py
@@ -63,7 +63,7 @@ class RaidEvent(BaseEvent):
         self.geofence = Unknown.REGULAR
         self.custom_dts = {}
 
-    def generate_dts(self, locale, timezone):
+    def generate_dts(self, locale, timezone, units):
         """ Return a dict with all the DTS for this event. """
         raid_end_time = get_time_as_str(self.raid_end, timezone)
         dts = self.custom_dts.copy()
@@ -83,8 +83,8 @@ class RaidEvent(BaseEvent):
             'lat_5': "{:.5f}".format(self.lat),
             'lng_5': "{:.5f}".format(self.lng),
             'distance': (
-                get_dist_as_str(self.distance) if Unknown.is_not(self.distance)
-                else Unknown.SMALL),
+                get_dist_as_str(self.distance, units)
+                if Unknown.is_not(self.distance) else Unknown.SMALL),
             'direction': self.direction,
             'gmaps': get_gmaps_link(self.lat, self.lng),
             'applemaps': get_applemaps_link(self.lat, self.lng),

--- a/PokeAlarm/Events/RaidEvent.py
+++ b/PokeAlarm/Events/RaidEvent.py
@@ -63,9 +63,9 @@ class RaidEvent(BaseEvent):
         self.geofence = Unknown.REGULAR
         self.custom_dts = {}
 
-    def generate_dts(self, locale):
+    def generate_dts(self, locale, timezone):
         """ Return a dict with all the DTS for this event. """
-        raid_end_time = get_time_as_str(self.raid_end)
+        raid_end_time = get_time_as_str(self.raid_end, timezone)
         dts = self.custom_dts.copy()
         cp_range = get_pokemon_cp_range(self.mon_id, 20)
         dts.update({

--- a/PokeAlarm/Events/StopEvent.py
+++ b/PokeAlarm/Events/StopEvent.py
@@ -34,7 +34,7 @@ class StopEvent(BaseEvent):
         self.geofence = Unknown.REGULAR
         self.custom_dts = {}
 
-    def generate_dts(self, locale, timezone):
+    def generate_dts(self, locale, timezone, units):
         """ Return a dict with all the DTS for this event. """
         time = get_time_as_str(self.expiration)
         dts = self.custom_dts.copy()
@@ -53,8 +53,8 @@ class StopEvent(BaseEvent):
             'lat_5': "{:.5f}".format(self.lat),
             'lng_5': "{:.5f}".format(self.lat),
             'distance': (
-                get_dist_as_str(self.distance) if Unknown.is_not(self.distance)
-                else Unknown.SMALL),
+                get_dist_as_str(self.distance, units)
+                if Unknown.is_not(self.distance) else Unknown.SMALL),
             'direction': self.direction,
             'gmaps': get_gmaps_link(self.lat, self.lng),
             'applemaps': get_applemaps_link(self.lat, self.lng),

--- a/PokeAlarm/Events/StopEvent.py
+++ b/PokeAlarm/Events/StopEvent.py
@@ -34,7 +34,7 @@ class StopEvent(BaseEvent):
         self.geofence = Unknown.REGULAR
         self.custom_dts = {}
 
-    def generate_dts(self, locale):
+    def generate_dts(self, locale, timezone):
         """ Return a dict with all the DTS for this event. """
         time = get_time_as_str(self.expiration)
         dts = self.custom_dts.copy()

--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -331,9 +331,6 @@ class Manager(object):
     def setup_in_process(self):
 
         # Update config
-        config['TIMEZONE'] = self.__timezone
-        config['API_KEY'] = self.__google_key
-        config['UNITS'] = self.__units
         config['DEBUG'] = self.__debug
         config['ROOT_PATH'] = os.path.abspath(
             "{}/..".format(os.path.dirname(__file__)))
@@ -487,7 +484,7 @@ class Manager(object):
             return
 
         # Generate the DTS for the event
-        dts = mon.generate_dts(self.__locale)
+        dts = mon.generate_dts(self.__locale, self.__timezone)
 
         if self.__loc_service:
             self.__loc_service.add_optional_arguments(
@@ -547,7 +544,7 @@ class Manager(object):
             return
 
         # Generate the DTS for the event
-        dts = stop.generate_dts(self.__locale)
+        dts = stop.generate_dts(self.__locale, self.__timezone)
         if self.__loc_service:
             self.__loc_service.add_optional_arguments(
                 self.__location, [stop.lat, stop.lng], dts)
@@ -616,7 +613,7 @@ class Manager(object):
             return
 
         # Generate the DTS for the event
-        dts = gym.generate_dts(self.__locale)
+        dts = gym.generate_dts(self.__locale, self.__timezone)
         dts.update(self.__cache.get_gym_info(gym.gym_id))  # update gym info
         if self.__loc_service:
             self.__loc_service.add_optional_arguments(
@@ -687,7 +684,7 @@ class Manager(object):
             return
 
         # Generate the DTS for the event
-        dts = egg.generate_dts(self.__locale)
+        dts = egg.generate_dts(self.__locale, self.__timezone)
         dts.update(self.__cache.get_gym_info(egg.gym_id))  # update gym info
         if self.__loc_service:
             self.__loc_service.add_optional_arguments(
@@ -758,7 +755,7 @@ class Manager(object):
             return
 
         # Generate the DTS for the event
-        dts = raid.generate_dts(self.__locale)
+        dts = raid.generate_dts(self.__locale, self.__timezone)
         dts.update(self.__cache.get_gym_info(raid.gym_id))  # update gym info
         if self.__loc_service:
             self.__loc_service.add_optional_arguments(

--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -484,7 +484,7 @@ class Manager(object):
             return
 
         # Generate the DTS for the event
-        dts = mon.generate_dts(self.__locale, self.__timezone)
+        dts = mon.generate_dts(self.__locale, self.__timezone, self.__units)
 
         if self.__loc_service:
             self.__loc_service.add_optional_arguments(
@@ -544,7 +544,7 @@ class Manager(object):
             return
 
         # Generate the DTS for the event
-        dts = stop.generate_dts(self.__locale, self.__timezone)
+        dts = stop.generate_dts(self.__locale, self.__timezone, self.__units)
         if self.__loc_service:
             self.__loc_service.add_optional_arguments(
                 self.__location, [stop.lat, stop.lng], dts)
@@ -613,7 +613,7 @@ class Manager(object):
             return
 
         # Generate the DTS for the event
-        dts = gym.generate_dts(self.__locale, self.__timezone)
+        dts = gym.generate_dts(self.__locale, self.__timezone, self.__units)
         dts.update(self.__cache.get_gym_info(gym.gym_id))  # update gym info
         if self.__loc_service:
             self.__loc_service.add_optional_arguments(
@@ -684,7 +684,7 @@ class Manager(object):
             return
 
         # Generate the DTS for the event
-        dts = egg.generate_dts(self.__locale, self.__timezone)
+        dts = egg.generate_dts(self.__locale, self.__timezone, units)
         dts.update(self.__cache.get_gym_info(egg.gym_id))  # update gym info
         if self.__loc_service:
             self.__loc_service.add_optional_arguments(
@@ -755,7 +755,7 @@ class Manager(object):
             return
 
         # Generate the DTS for the event
-        dts = raid.generate_dts(self.__locale, self.__timezone)
+        dts = raid.generate_dts(self.__locale, self.__timezone, self.__units)
         dts.update(self.__cache.get_gym_info(raid.gym_id))  # update gym info
         if self.__loc_service:
             self.__loc_service.add_optional_arguments(

--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -684,7 +684,7 @@ class Manager(object):
             return
 
         # Generate the DTS for the event
-        dts = egg.generate_dts(self.__locale, self.__timezone, units)
+        dts = egg.generate_dts(self.__locale, self.__timezone, self.__units)
         dts.update(self.__cache.get_gym_info(egg.gym_id))  # update gym info
         if self.__loc_service:
             self.__loc_service.add_optional_arguments(

--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -1,17 +1,16 @@
 # Standard Library Imports
-import Queue
 import json
 import logging
-import multiprocessing
 import os
 import re
 import sys
 import traceback
 from datetime import datetime, timedelta
 
-import gevent
 # 3rd Party Imports
-import gipc
+import gevent
+from gevent.queue import Queue
+from gevent.event import Event
 
 # Local Imports
 import Alarms
@@ -86,8 +85,8 @@ class Manager(object):
         self.load_alarms_file(get_path(alarm_file), int(max_attempts))
 
         # Initialize the queue and start the process
-        self.__queue = multiprocessing.Queue()
-        self.__event = multiprocessing.Event()
+        self.__queue = Queue()
+        self.__event = Event()
         self.__process = None
 
         log.info("----------- Manager '{}' ".format(self.__name)
@@ -110,11 +109,11 @@ class Manager(object):
         self.__event.set()
 
     def join(self):
-        self.__process.join(timeout=10)
-        if self.__process.is_alive():
+        self.__process.join()
+        if not self.__process.ready():
             log.warning("Manager {} could not be stopped in time!"
-                        + " Forcing process to stop.")
-            self.__process.terminate()
+                        " Forcing process to stop.".format(self.__name))
+            self.__process.kill(timeout=2, block=True)  # Force stop
         else:
             log.info("Manager {} successfully stopped!".format(self.__name))
 
@@ -327,13 +326,9 @@ class Manager(object):
 
     # Start it up
     def start(self):
-        self.__process = gipc.start_process(
-            target=self.run, args=(), name=self.__name)
+        self.__process = gevent.spawn(self.run)
 
     def setup_in_process(self):
-        # Set up signal handlers for graceful exit
-        gevent.signal(gevent.signal.SIGINT, self.stop)
-        gevent.signal(gevent.signal.SIGTERM, self.stop)
 
         # Update config
         config['TIMEZONE'] = self.__timezone
@@ -369,7 +364,7 @@ class Manager(object):
 
             try:  # Get next object to process
                 event = self.__queue.get(block=True, timeout=5)
-            except Queue.Empty:
+            except gevent.queue.Empty:
                 # Check if the process should exit process
                 if self.__event.is_set():
                     break
@@ -402,7 +397,7 @@ class Manager(object):
             gevent.sleep(0)
         # Save cache and exit
         self.__cache.clean_and_save()
-        exit(0)
+        raise gevent.GreenletExit()
 
     # Set the location of the Manager
     def set_location(self, location):

--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -109,7 +109,7 @@ class Manager(object):
         self.__event.set()
 
     def join(self):
-        self.__process.join()
+        self.__process.join(timeout=20)
         if not self.__process.ready():
             log.warning("Manager {} could not be stopped in time!"
                         " Forcing process to stop.".format(self.__name))

--- a/PokeAlarm/Utils.py
+++ b/PokeAlarm/Utils.py
@@ -338,8 +338,8 @@ def get_cardinal_dir(pt_a, pt_b=None):
 
 
 # Return the distance formatted correctly
-def get_dist_as_str(dist):
-    if config['UNITS'] == 'imperial':
+def get_dist_as_str(dist, units):
+    if units == 'imperial':
         if dist > 1760:  # yards per mile
             return "{:.1f}mi".format(dist / 1760.0)
         else:
@@ -352,7 +352,7 @@ def get_dist_as_str(dist):
 
 
 # Returns an integer representing the distance between A and B
-def get_earth_dist(pt_a, pt_b=None):
+def get_earth_dist(pt_a, pt_b=None, units='imperial'):
     if type(pt_a) is str or pt_b is None:
         return 'unkn'  # No location set
     log.debug("Calculating distance from {} to {}".format(pt_a, pt_b))
@@ -366,7 +366,7 @@ def get_earth_dist(pt_a, pt_b=None):
         cos(lat_b) * sin(lng_delta / 2) ** 2
     c = 2 * atan2(sqrt(a), sqrt(1 - a))
     radius = 6373000  # radius of earth in meters
-    if config['UNITS'] == 'imperial':
+    if units == 'imperial':
         radius = 6975175  # radius of earth in yards
     dist = c * radius
     return dist

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 configargparse==0.12.0
 flask==0.12.2
 gevent==1.2.2
-gipc==0.6.0
 googlemaps==2.5.1
 pytz==2017.3
 portalocker==1.1.0

--- a/start_pokealarm.py
+++ b/start_pokealarm.py
@@ -40,6 +40,7 @@ log = logging.getLogger('Server')
 app = Flask(__name__)
 data_queue = queue.Queue()
 managers = {}
+server = None
 
 
 @app.route('/', methods=['GET'])
@@ -100,6 +101,7 @@ def start_server():
     log.info("PokeAlarm is listening for webhooks on: http://{}:{}".format(
         config['HOST'], config['PORT']))
     threads = pool.Pool(config['CONCURRENCY'])
+    global server
     server = wsgi.WSGIServer(
         (config['HOST'], config['PORT']), app, log=logging.getLogger('pywsgi'),
         spawn=threads)
@@ -273,6 +275,7 @@ def get_from_list(arg, i, default):
 
 def exit_gracefully():
     log.info("PokeAlarm is closing down!")
+    server.stop()
     for m_name in managers:
         managers[m_name].stop()
     for m_name in managers:

--- a/start_pokealarm.py
+++ b/start_pokealarm.py
@@ -12,15 +12,15 @@ logging.basicConfig(
            + '[%(levelname)8.8s] %(message)s', level=logging.INFO)
 
 # Standard Library Imports
-import configargparse
-from gevent import wsgi, spawn, signal, pool
-import pytz
-import Queue
+
 import json
 import os
 import sys
 # 3rd Party Imports
+import configargparse
+from gevent import wsgi, spawn, signal, pool, queue
 from flask import Flask, request, abort
+import pytz
 # Local Imports
 import PokeAlarm.Events as Events
 from PokeAlarm import config
@@ -38,7 +38,7 @@ log = logging.getLogger('Server')
 
 # Global Variables
 app = Flask(__name__)
-data_queue = Queue.Queue()
+data_queue = queue.Queue()
 managers = {}
 
 
@@ -79,7 +79,6 @@ def manage_webhook_data(queue):
                 log.debug("Distributing event {} to manager {}.".format(
                     obj.id, name))
             log.debug("Finished distributing event: {}".format(obj.id))
-        queue.task_done()
 
 
 # Configure and run PokeAlarm


### PR DESCRIPTION
Remove multiprocessing and gipc and substitute greenlets instead. The queues in multiprocessing/gipc are process blocking which is causing unnecessary overhead from context switches. 

Thanks to @sebastienvercammen for pointing out the flaw in our setup.