### PR TITLE
Weather DTS improvements

### DIFF
--- a/PokeAlarm/Events/EggEvent.py
+++ b/PokeAlarm/Events/EggEvent.py
@@ -3,7 +3,7 @@ from datetime import datetime
 # 3rd Party Imports
 # Local Imports
 from PokeAlarm.Utils import get_time_as_str, get_seconds_remaining, \
-    get_gmaps_link, get_applemaps_link, get_dist_as_str
+    get_gmaps_link, get_applemaps_link, get_dist_as_str, get_weather_emoji
 from . import BaseEvent
 from PokeAlarm import Unknown
 
@@ -31,6 +31,8 @@ class EggEvent(BaseEvent):
         self.lng = float(data['longitude'])
         self.distance = Unknown.SMALL  # Completed by Manager
         self.direction = Unknown.TINY  # Completed by Manager
+        self.weather_id = check_for_none(
+            int, data.get('weather'), Unknown.TINY)
 
         # Egg Info
         self.egg_lvl = check_for_none(int, data.get('level'), 0)
@@ -55,6 +57,7 @@ class EggEvent(BaseEvent):
         """ Return a dict with all the DTS for this event. """
         hatch_time = get_time_as_str(self.hatch_time, timezone)
         raid_end_time = get_time_as_str(self.raid_end, timezone)
+        weather_name = locale.get_weather_name(self.weather_id)
         dts = self.custom_dts.copy()
         dts.update({
             # Identification
@@ -80,6 +83,10 @@ class EggEvent(BaseEvent):
             'gmaps': get_gmaps_link(self.lat, self.lng),
             'applemaps': get_applemaps_link(self.lat, self.lng),
             'geofence': self.geofence,
+            'weather_id': self.weather_id,
+            'weather': weather_name,
+            'weather_or_empty': Unknown.or_empty(weather_name),
+            'weather_emoji': get_weather_emoji(self.weather_id),
 
             # Egg info
             'egg_lvl': self.egg_lvl,

--- a/PokeAlarm/Events/MonEvent.py
+++ b/PokeAlarm/Events/MonEvent.py
@@ -41,6 +41,8 @@ class MonEvent(BaseEvent):
         self.direction = Unknown.TINY  # Completed by Manager
         self.weather_id = check_for_none(
             int, data.get('weather'), Unknown.TINY)
+        self.boosted_weather_id = check_for_none(
+            int, data.get('boosted_weather'), 0)
 
         # Encounter Stats
         self.mon_lvl = check_for_none(
@@ -99,8 +101,11 @@ class MonEvent(BaseEvent):
         time = get_time_as_str(self.disappear_time, timezone)
         form_name = locale.get_form_name(self.monster_id, self.form_id)
         weather_name = locale.get_weather_name(self.weather_id)
+        boosted_weather_name = locale.get_weather_name(self.boosted_weather_id)
+
         type1 = locale.get_type_name(self.types[0])
         type2 = locale.get_type_name(self.types[1])
+
         dts = self.custom_dts.copy()
         dts.update({
             # Identification
@@ -135,6 +140,11 @@ class MonEvent(BaseEvent):
             'weather': weather_name,
             'weather_or_empty': Unknown.or_empty(weather_name),
             'weather_emoji': get_weather_emoji(self.weather_id),
+            'boosted_weather_id': self.boosted_weather_id,
+            'boosted_weather': boosted_weather_name,
+            'boosted_weather_or_empty': Unknown.or_empty(boosted_weather_name),
+            'boosted_weather_emoji':
+                get_weather_emoji(self.boosted_weather_id),
 
             # Encounter Stats
             'mon_lvl': self.mon_lvl,

--- a/PokeAlarm/Events/RaidEvent.py
+++ b/PokeAlarm/Events/RaidEvent.py
@@ -77,12 +77,17 @@ class RaidEvent(BaseEvent):
         dts = self.custom_dts.copy()
 
         boss_level = 20
+        boosted_weather = 0
         if Unknown.is_not(self.weather_id) \
                 and is_weather_boosted(self.mon_id, self.weather_id):
             boss_level = 25
+            boosted_weather = self.weather_id
+        boosted_weather_name = locale.get_weather_name(boosted_weather)
         weather_name = locale.get_weather_name(self.weather_id)
+
         type1 = locale.get_type_name(self.types[0])
         type2 = locale.get_type_name(self.types[1])
+
         cp_range = get_pokemon_cp_range(self.mon_id, boss_level)
         dts.update({
             # Identification
@@ -118,6 +123,10 @@ class RaidEvent(BaseEvent):
             'weather': weather_name,
             'weather_or_empty': Unknown.or_empty(weather_name),
             'weather_emoji': get_weather_emoji(self.weather_id),
+            'boosted_weather_id': boosted_weather,
+            'boosted_weather': boosted_weather_name,
+            'boosted_weather_or_empty': Unknown.or_empty(boosted_weather_name),
+            'boosted_weather_emoji': get_weather_emoji(boosted_weather),
 
             # Raid Info
             'raid_lvl': self.raid_lvl,


### PR DESCRIPTION
## Description
In my last PR, I added weather to PokeAlarm. There seems to exist now some confusion between what is the in-game weather, and the weather boosted condition of mons and raids. This PR should fix that.

The <weather> DTSs will now be used for the current in game weather for the location of the spawn or raid. The <boosted_weather> DTSs will be used to reflect whether the spawn or raid boss is boosted by the weather. 

The <weather> DTS will return the weather or 'unknown', and the <boosted_weather> will return the weather or 'None'.

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## How Has This Been Tested?
<!---
I have not yet tested this in my production environment, hence the WIP flag. Hopefully this will prompt discussion and highlight changes that may be needed. Comment in beta-chat to discuss :)
-->

## Checklist
- [x] This change follows the code style of this project.
- [ ] This change only changes what is necessary to the feature.
