### PR TITLE
Removing <boosted_weather_or_empty> DTS

### DIFF
--- a/PokeAlarm/Events/MonEvent.py
+++ b/PokeAlarm/Events/MonEvent.py
@@ -142,7 +142,6 @@ class MonEvent(BaseEvent):
             'weather_emoji': get_weather_emoji(self.weather_id),
             'boosted_weather_id': self.boosted_weather_id,
             'boosted_weather': boosted_weather_name,
-            'boosted_weather_or_empty': Unknown.or_empty(boosted_weather_name),
             'boosted_weather_emoji':
                 get_weather_emoji(self.boosted_weather_id),
 

--- a/PokeAlarm/Events/RaidEvent.py
+++ b/PokeAlarm/Events/RaidEvent.py
@@ -125,7 +125,6 @@ class RaidEvent(BaseEvent):
             'weather_emoji': get_weather_emoji(self.weather_id),
             'boosted_weather_id': boosted_weather,
             'boosted_weather': boosted_weather_name,
-            'boosted_weather_or_empty': Unknown.or_empty(boosted_weather_name),
             'boosted_weather_emoji': get_weather_emoji(boosted_weather),
 
             # Raid Info


### PR DESCRIPTION
## Description
`<boosted_weather>` can never be empty, so the `<boosted_weather_or_empty>` DTS is un-necessary.  Removing from code. 

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
@evilmoses requested someone to put in a change to fix this. 

## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change to https://github.com/RocketMap/PokeAlarmWiki.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [x] This change requires an update to the Wiki.
- [ ] This change does not require an update to the Wiki.


## Checklist
- [x] This change follows the code style of this project.
- [x] This change only changes what is necessary to the feature.
