### PR TITLE
Fix boosted_weather_or_empty

### DIFF
--- a/PokeAlarm/Events/MonEvent.py
+++ b/PokeAlarm/Events/MonEvent.py
@@ -144,7 +144,7 @@ class MonEvent(BaseEvent):
             'weather_emoji': get_weather_emoji(self.weather_id),
             'boosted_weather_id': self.boosted_weather_id,
             'boosted_weather': boosted_weather_name,
-            'boosted_weather_or_empty': Unknown.or_empty(boosted_weather_name),
+            'boosted_weather_or_empty': '' if self.boosted_weather_id == 0 else boosted_weather_name,
             'boosted_weather_emoji':
                 get_weather_emoji(self.boosted_weather_id),
 

--- a/PokeAlarm/Events/MonEvent.py
+++ b/PokeAlarm/Events/MonEvent.py
@@ -144,7 +144,8 @@ class MonEvent(BaseEvent):
             'weather_emoji': get_weather_emoji(self.weather_id),
             'boosted_weather_id': self.boosted_weather_id,
             'boosted_weather': boosted_weather_name,
-            'boosted_weather_or_empty': '' if self.boosted_weather_id == 0 else boosted_weather_name,
+            'boosted_weather_or_empty':
+                '' if self.boosted_weather_id == 0 else boosted_weather_name,
             'boosted_weather_emoji':
                 get_weather_emoji(self.boosted_weather_id),
 

--- a/PokeAlarm/Events/RaidEvent.py
+++ b/PokeAlarm/Events/RaidEvent.py
@@ -132,7 +132,7 @@ class RaidEvent(BaseEvent):
             'weather_emoji': get_weather_emoji(self.weather_id),
             'boosted_weather_id': boosted_weather,
             'boosted_weather': boosted_weather_name,
-            'boosted_weather_or_empty': Unknown.or_empty(boosted_weather_name),
+            'boosted_weather_or_empty': '' if self.boosted_weather_id == 0 else boosted_weather_name,
             'boosted_weather_emoji': get_weather_emoji(boosted_weather),
 
             # Raid Info

--- a/PokeAlarm/Events/RaidEvent.py
+++ b/PokeAlarm/Events/RaidEvent.py
@@ -132,7 +132,8 @@ class RaidEvent(BaseEvent):
             'weather_emoji': get_weather_emoji(self.weather_id),
             'boosted_weather_id': boosted_weather,
             'boosted_weather': boosted_weather_name,
-            'boosted_weather_or_empty': '' if self.boosted_weather_id == 0 else boosted_weather_name,
+            'boosted_weather_or_empty':
+                '' if self.boosted_weather_id == 0 else boosted_weather_name,
             'boosted_weather_emoji': get_weather_emoji(boosted_weather),
 
             # Raid Info


### PR DESCRIPTION
## Description
Currently boosted_weather_or_empty never returns empty, as the boosted_weather_name is never empty. This PR fixes that

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

