### PR TITLE
Fix Twitter Truncation

### DIFF
--- a/PokeAlarm/Alarms/Twitter/TwitterAlarm.py
+++ b/PokeAlarm/Alarms/Twitter/TwitterAlarm.py
@@ -119,7 +119,7 @@ class TwitterAlarm(Alarm):
                     break  # Don't add the url
                 word_len = url_length  # URL's have a fixed length
             elif word_len >= limit:  # If the word doesn't fit
-                word_len = limit-1
+                word_len = limit - 1
                 word = word[:word_len]  # truncate it
             limit -= word_len + 1  # word + space
             msg += " " + word


### PR DESCRIPTION
This address an issue with twitter truncation. First, the limit has been extended to 280 characters. Second the truncation now correctly works after DTS. Finally, it counts all urls as 23 characters (instead of just `<gmaps>`.

Please note this change includes the latest verson of dev, including the rules update. Please see here for more info on converting your alarms file: https://github.com/PokeAlarm/PokeAlarm/pull/564