### PR TITLE
Weather Fixes

### DIFF
--- a/PokeAlarm/Events/MonEvent.py
+++ b/PokeAlarm/Events/MonEvent.py
@@ -44,7 +44,7 @@ class MonEvent(BaseEvent):
         self.weather_id = check_for_none(
             int, data.get('weather'), Unknown.TINY)
         self.boosted_weather_id = check_for_none(
-            int, data.get('boosted_weather'), Unknown.TINY)
+            int, data.get('boosted_weather'), 0)
 
         # Encounter Stats
         self.mon_lvl = check_for_none(


### PR DESCRIPTION
## Description
This PR fixes some issues in the weather alerts for mons and raids:

1. MonEvent - Changed back to setting boosted weather to 0. This is because if mon is not weather boosted scan sends None to webhook, so there is no way to differentiate between sent and not boosted and not sent. Having it set to ? mean all unboosted mons were posting unknown instead of 'None'.
1. There is an unnecessary comma that appends to a string, meaning later name lookups fails.

```
boosted_weather_id = \
            0 if Unknown.is_not(self.weather_id) else Unknown.TINY,
```

The comma at the end was causing issues. I have also tidied up the code to make it similar to MonEvent

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)