### PR TITLE
Fix Geofence ordering in Filters. 

### DIFF
--- a/PokeAlarm/Filters/BaseFilter.py
+++ b/PokeAlarm/Filters/BaseFilter.py
@@ -1,4 +1,5 @@
 # Standard Library Imports
+import collections
 import logging
 import json
 # 3rd Party Imports
@@ -78,6 +79,25 @@ class BaseFilter(object):
             raise ValueError(
                 'Unable to interpret the value "{}" as a '.format(value) +
                 'valid {} for parameter {}.", '.format(kind, param_name))
+
+    @staticmethod
+    def parse_as_list(value_type, param_name, data):
+        """ Parse and convert a list of values into a list."""
+        # Validate Input
+        values = data.pop(param_name, None)
+        if values is None or len(values) == 0:
+            return None
+        if not isinstance(values, list):
+            raise ValueError(
+                'The "{0}" parameter must formatted as a list containing '
+                'different values. Example: "{0}": '
+                '[ "value1", "value2", "value3" ] '.format(param_name))
+        # Generate Allowed Set
+        allowed = []
+        for value in values:
+            # Value type should throw the correct error
+            allowed.append(value_type(value))
+        return allowed
 
     @staticmethod
     def parse_as_set(value_type, param_name, data):

--- a/PokeAlarm/Filters/BaseFilter.py
+++ b/PokeAlarm/Filters/BaseFilter.py
@@ -1,5 +1,4 @@
 # Standard Library Imports
-import collections
 import logging
 import json
 # 3rd Party Imports

--- a/PokeAlarm/Filters/EggFilter.py
+++ b/PokeAlarm/Filters/EggFilter.py
@@ -53,7 +53,7 @@ class EggFilter(BaseFilter):
                 GymUtils.get_team_id, 'current_teams', data))
 
         # Geofences
-        self.geofences = BaseFilter.parse_as_set(str, 'geofences', data)
+        self.geofences = BaseFilter.parse_as_list(str, 'geofences', data)
 
         # Custom DTS
         self.custom_dts = BaseFilter.parse_as_dict(

--- a/PokeAlarm/Filters/GymFilter.py
+++ b/PokeAlarm/Filters/GymFilter.py
@@ -48,7 +48,7 @@ class GymFilter(BaseFilter):
             limit=BaseFilter.parse_as_type(int, 'max_slots', data))
 
         # Geofences
-        self.geofences = BaseFilter.parse_as_set(str, 'geofences', data)
+        self.geofences = BaseFilter.parse_as_list(str, 'geofences', data)
 
         # Custom DTS
         self.custom_dts = BaseFilter.parse_as_dict(

--- a/PokeAlarm/Filters/MonFilter.py
+++ b/PokeAlarm/Filters/MonFilter.py
@@ -137,7 +137,7 @@ class MonFilter(BaseFilter):
             limit=BaseFilter.parse_as_set(get_weather_id, 'weather', data))
 
         # Geofences
-        self.geofences = BaseFilter.parse_as_set(str, 'geofences', data)
+        self.geofences = BaseFilter.parse_as_list(str, 'geofences', data)
 
         # Custom DTS
         self.custom_dts = BaseFilter.parse_as_dict(

--- a/PokeAlarm/Filters/RaidFilter.py
+++ b/PokeAlarm/Filters/RaidFilter.py
@@ -84,7 +84,7 @@ class RaidFilter(BaseFilter):
             limit=BaseFilter.parse_as_set(get_weather_id, 'weather', data))
 
         # Geofences
-        self.geofences = BaseFilter.parse_as_set(str, 'geofences', data)
+        self.geofences = BaseFilter.parse_as_list(str, 'geofences', data)
 
         # Custom DTS
         self.custom_dts = BaseFilter.parse_as_dict(

--- a/PokeAlarm/Filters/StopFilter.py
+++ b/PokeAlarm/Filters/StopFilter.py
@@ -31,7 +31,7 @@ class StopFilter(BaseFilter):
             limit=BaseFilter.parse_as_type(int, 'max_time_left', data))
 
         # Geofences
-        self.geofences = BaseFilter.parse_as_set(str, 'geofences', data)
+        self.geofences = BaseFilter.parse_as_list(str, 'geofences', data)
 
         # Custom DTS
         self.custom_dts = BaseFilter.parse_as_dict(


### PR DESCRIPTION
This fix is for https://github.com/PokeAlarm/PokeAlarm/issues/601 and corrects filter geofences to be checked in order specified in the filter.