### PR TITLE
Caching Improvements

### DIFF
--- a/PokeAlarm/Cache/Cache.py
+++ b/PokeAlarm/Cache/Cache.py
@@ -3,7 +3,8 @@ import logging
 from datetime import datetime
 # 3rd Party Imports
 # Local Imports
-from ..Utils import get_image_url
+from PokeAlarm import Unknown
+from PokeAlarm.Utils import get_image_url
 
 log = logging.getLogger('Cache')
 
@@ -15,70 +16,66 @@ class Cache(object):
     be lost between run times if save has not been implemented correctly.
     """
 
-    _default_gym_info = {
-        "name": "unknown",
-        "description": "unknown",
-        "url": get_image_url('icons/gym_0.png')
-    }
+    default_image_url = get_image_url("regular/gyms/0.png"),
 
     def __init__(self):
         """ Initializes a new cache object for storing data between events. """
-        self._pokemon_hist = {}
-        self._pokestop_hist = {}
-        self._gym_team = {}
-        self._gym_info = {}
+        self._mon_hist = {}
+        self._stop_hist = {}
         self._egg_hist = {}
         self._raid_hist = {}
+        self._gym_team = {}
+        self._gym_name = {}
+        self._gym_desc = {}
+        self._gym_image = {}
 
-    def get_pokemon_expiration(self, pkmn_id):
-        """ Get the datetime that the pokemon expires."""
-        return self._pokemon_hist.get(pkmn_id)
+    def monster_expiration(self, mon_id, expiration=None):
+        """ Update and return the datetime that a monster expires."""
+        if expiration is not None:
+            self._mon_hist[mon_id] = expiration
+        return self._mon_hist.get(mon_id)
 
-    def update_pokemon_expiration(self, pkmn_id, expiration):
-        """ Updates the datetime that the pokemon expires. """
-        self._pokemon_hist[pkmn_id] = expiration
+    def stop_expiration(self, stop_id, expiration=None):
+        """ Update and return the datetime that a stop expires."""
+        if expiration is not None:
+            self._stop_hist[stop_id] = expiration
+        return self._stop_hist.get(stop_id)
 
-    def get_pokestop_expiration(self, stop_id):
-        """ Returns the datetime that the pokemon expires. """
-        return self._pokestop_hist.get(stop_id)
+    def egg_expiration(self, egg_id, expiration=None):
+        """ Update and return the datetime that an egg expires."""
+        if expiration is not None:
+            self._egg_hist[egg_id] = expiration
+        return self._egg_hist.get(egg_id)
 
-    def update_pokestop_expiration(self, stop_id, expiration):
-        """ Updates the datetime that the pokestop expires. """
-        self._pokestop_hist[stop_id] = expiration
+    def raid_expiration(self, raid_id, expiration=None):
+        """ Update and return the datetime that a raid expires."""
+        if expiration is not None:
+            self._raid_hist[raid_id] = expiration
+        return self._raid_hist.get(raid_id)
 
-    def get_gym_team(self, gym_id):
-        """ Get the current team that owns the gym. """
-        return self._gym_team.get(gym_id, '?')
+    def gym_team(self, gym_id, team_id=Unknown.TINY):
+        """ Update and return the team_id of a gym. """
+        if Unknown.is_not(team_id):
+            self._gym_team[gym_id] = team_id
+        return self._gym_team.get(gym_id, Unknown.TINY)
 
-    def update_gym_team(self, gym_id, team):
-        """ Update the current team of the gym. """
-        self._gym_team[gym_id] = team
+    def gym_name(self, gym_id, gym_name=Unknown.REGULAR):
+        """ Update and return the gym_name for a gym. """
+        if Unknown.is_not(gym_name):
+            self._gym_name[gym_id] = gym_name
+        return self._gym_name.get(gym_id, Unknown.REGULAR)
 
-    def get_gym_info(self, gym_id):
-        """ Gets the information about the gym. """
-        return self._gym_info.get(gym_id, self._default_gym_info)
+    def gym_desc(self, gym_id, gym_desc=Unknown.REGULAR):
+        """ Update and return the gym_desc for a gym. """
+        if Unknown.is_not(gym_desc):
+            self._gym_desc[gym_id] = gym_desc
+        return self._gym_desc.get(gym_id, Unknown.REGULAR)
 
-    def update_gym_info(self, gym_id, name, desc, url):
-        """ Updates the information about the gym. """
-        if name != 'unknown':  # Don't update if the gym info is missing
-            self._gym_info[gym_id] = {
-                "name": name, "description": desc, "url": url}
-
-    def get_egg_expiration(self, gym_id):
-        """ Returns the datetime that the egg expires. """
-        return self._egg_hist.get(gym_id)
-
-    def update_egg_expiration(self, gym_id, expiration):
-        """ Updates the datetime that the egg expires. """
-        self._egg_hist[gym_id] = expiration
-
-    def get_raid_expiration(self, gym_id):
-        """ Returns the datetime that the raid expires. """
-        return self._raid_hist.get(gym_id)
-
-    def update_raid_expiration(self, gym_id, expiration):
-        """ Updates the datetime that the raid expires. """
-        self._raid_hist[gym_id] = expiration
+    def gym_image(self, gym_id, gym_image=Unknown.REGULAR):
+        """ Update and return the gym_image for a gym. """
+        if Unknown.is_not(gym_image):
+            self._gym_image[gym_id] = gym_image
+        return self._gym_image.get(gym_id, get_image_url('icons/gym_0.png'))
 
     def clean_and_save(self):
         """ Cleans the cache and saves the contents if capable. """
@@ -92,7 +89,7 @@ class Cache(object):
     def _clean_hist(self):
         """ Clean expired objects to free up memory. """
         for hist in (
-                self._pokemon_hist, self._pokestop_hist, self._egg_hist,
+                self._mon_hist, self._stop_hist, self._egg_hist,
                 self._raid_hist):
             old = []
             now = datetime.utcnow()

--- a/PokeAlarm/Cache/FileCache.py
+++ b/PokeAlarm/Cache/FileCache.py
@@ -67,6 +67,7 @@ class FileCache(Cache):
             temp = self._file + ".new"
             with portalocker.Lock(temp, timeout=5, mode="wb+") as f:
                 pickle.dump(data, f, protocol=pickle.HIGHEST_PROTOCOL)
+                os.remove(self._file)  # Required for Windows
                 os.rename(temp, self._file)
             log.debug("Cache saved successfully.")
         except Exception as e:

--- a/PokeAlarm/Cache/FileCache.py
+++ b/PokeAlarm/Cache/FileCache.py
@@ -21,6 +21,9 @@ class FileCache(Cache):
         self._file = get_path(os.path.join("cache", "{}.cache".format(name)))
 
         log.debug("Checking for previous cache at {}".format(self._file))
+        cache_folder = get_path("cache")
+        if not os.path.exists(cache_folder):
+            os.makedirs(cache_folder)
         if os.path.isfile(self._file):
             self._load()
         else:
@@ -28,33 +31,45 @@ class FileCache(Cache):
                 pickle.dump({}, f, protocol=pickle.HIGHEST_PROTOCOL)
 
     def _load(self):
-        with portalocker.Lock(self._file, mode="rb") as f:
-            data = pickle.load(f)
-            self._pokemon_hist = data.get('pokemon_hist', {})
-            self._pokestop_hist = data.get('pokestop_hist', {})
-            self._gym_team = data.get('gym_team', {})
-            self._gym_info = data.get('gym_info', {})
-            self._egg_hist = data.get('egg_hist', {})
-            self._raid_hist = data.get('raid_hist', {})
-            log.debug("LOADED: \n {}".format(data))
+        try:
+            with portalocker.Lock(self._file, mode="rb") as f:
+                data = pickle.load(f)
+                self._mon_hist = data.get('mon_hist', {})
+                self._stop_hist = data.get('stop_hist', {})
+                self._egg_hist = data.get('egg_hist', {})
+                self._raid_hist = data.get('raid_hist', {})
+                self._gym_team = data.get('gym_team', {})
+                self._gym_name = data.get('gym_name', {})
+                self._gym_desc = data.get('gym_desc', {})
+                self._gym_image = data.get('gym_image', {})
+
+                log.debug("Cache loaded successfully.")
+        except Exception as e:
+            log.error("There was an error attempting to load the cache. The "
+                      "old cache will be overwritten.")
+            log.error("{}: {}".format(type(e).__name__, e))
 
     def _save(self):
         """ Export the data to a more permanent location. """
         log.debug("Writing cache to file...")
         data = {
-            'pokemon_hist': self._pokemon_hist,
-            'pokestop_hist': self._pokestop_hist,
-            'gym_team': self._gym_team,
-            'gym_info': self._gym_info,
+            'mon_hist': self._mon_hist,
+            'stop_hist': self._stop_hist,
             'egg_hist': self._egg_hist,
-            'raid_hist': self._raid_hist
+            'raid_hist': self._raid_hist,
+            'gym_team': self._gym_team,
+            'gym_name': self._gym_name,
+            'gym_desc': self._gym_desc,
+            'gym_image': self._gym_image
         }
-        log.debug(self._pokestop_hist)
-        log.debug("SAVED: {}".format(data))
         try:
-            with portalocker.Lock(self._file, timeout=5, mode="wb+") as f:
+            # Write to temporary file and then rename
+            temp = self._file + ".new"
+            with portalocker.Lock(temp, timeout=5, mode="wb+") as f:
                 pickle.dump(data, f, protocol=pickle.HIGHEST_PROTOCOL)
+                os.rename(temp, self._file)
+            log.debug("Cache saved successfully.")
         except Exception as e:
             log.error("Encountered error while saving cache: "
                       + "{}: {}".format(type(e).__name__, e))
-            log.debug("Stack trace: \n {}".format(traceback.format_exc()))
+            log.error("Stack trace: \n {}".format(traceback.format_exc()))

--- a/PokeAlarm/Events/EggEvent.py
+++ b/PokeAlarm/Events/EggEvent.py
@@ -47,7 +47,7 @@ class EggEvent(BaseEvent):
 
         # Gym Team (this is only available from cache)
         self.current_team_id = check_for_none(
-            int, data.get('team'), Unknown.TINY)
+            int, data.get('team_id', data.get('team')), Unknown.TINY)
 
         self.name = self.gym_id
         self.geofence = Unknown.REGULAR

--- a/PokeAlarm/Events/RaidEvent.py
+++ b/PokeAlarm/Events/RaidEvent.py
@@ -73,7 +73,7 @@ class RaidEvent(BaseEvent):
 
         # Gym Team (this is only available from cache)
         self.current_team_id = check_for_none(
-            int, data.get('team'), Unknown.TINY)
+            int, data.get('team_id', data.get('team')), Unknown.TINY)
 
         self.name = self.gym_id
         self.geofence = Unknown.REGULAR

--- a/cache/.gitignore
+++ b/cache/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore


### PR DESCRIPTION
This is a bunch of miscellaneous cache improvements.

* Updated API to be more condensed
* Separated gym_info into gym_name, gym_desc, and gym_url into separate endpoints
* Added support for `team_id` from RM egg and raid webhooks
* FileCache now creates the cache folder upon initialization if it doesn't exist
* FileCache saves initial file with the ".new" extension and then renames over the original file to reduce the chance of the cache being corrupted if PA is closed incorrectly
* If FileCache fails to load the file for any reason, it will continue on as normal and overwrite it the cache on the next opportunity 