### PR TITLE
bugfix: If the only address DTS you use is `<address_eu>` reverse geocode fails

### DIFF
--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -367,8 +367,9 @@ class Manager(object):
     # Check for optional arguments and enable APIs as needed
     def set_optional_args(self, line):
         # Reverse Location
-        args = {'street', 'street_num', 'address', 'postal', 'neighborhood',
-                'sublocality', 'city', 'county', 'state', 'country'}
+        args = {'street', 'street_num', 'address', 'address_eu',
+                'postal', 'neighborhood', 'sublocality', 'city', 'county',
+                'state', 'country'}
         if contains_arg(line, args):
             if self.__loc_service is None:
                 log.critical("Reverse location DTS were detected but "


### PR DESCRIPTION

## Description
if your alarm DTS only contains address_eu , geocode lookup won't happen and the alarm will become <address_eu>

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
It makes alarms great again also in parts of the world that likes to write `street streetnumber`

## How Has This Been Tested?
<!---
 Please describe in detail how you tested your changes. Make sure to
 describe what tests you have performed, your testing environment,
 and if you have used this in a production setting.
-->

## Screenshots (if appropriate):


## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change to https://github.com/RocketMap/PokeAlarmWiki.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [ ] This change requires an update to the Wiki.
- [x] This change does not require an update to the Wiki.


## Checklist
- [x] This change follows the code style of this project.
- [x] This change only changes what is necessary to the feature.
