### PR TITLE
Adds gym_name_excludes filter to Gym, Egg, Raid Events

### DIFF
--- a/PokeAlarm/Filters/EggFilter.py
+++ b/PokeAlarm/Filters/EggFilter.py
@@ -45,6 +45,11 @@ class EggFilter(BaseFilter):
             event_attribute='gym_name', eval_func=GymUtils.match_regex_dict,
             limit=BaseFilter.parse_as_set(
                 GymUtils.create_regex, 'gym_name_contains', data))
+        self.gym_name_excludes = self.evaluate_attribute(  # f.gn no-match e.gn
+            event_attribute='gym_name',
+            eval_func=GymUtils.not_match_regex_dict,
+            limit=BaseFilter.parse_as_set(
+                GymUtils.create_regex, 'gym_name_excludes', data))
 
         # Team Info
         self.old_team = self.evaluate_attribute(  # f.ctis contains m.cti

--- a/PokeAlarm/Filters/GymFilter.py
+++ b/PokeAlarm/Filters/GymFilter.py
@@ -36,6 +36,11 @@ class GymFilter(BaseFilter):
             event_attribute='gym_name', eval_func=GymUtils.match_regex_dict,
             limit=BaseFilter.parse_as_set(
                 GymUtils.create_regex, 'gym_name_contains', data))
+        self.gym_name_excludes = self.evaluate_attribute(  # f.gn no-match e.gn
+            event_attribute='gym_name',
+            eval_func=GymUtils.not_match_regex_dict,
+            limit=BaseFilter.parse_as_set(
+                GymUtils.create_regex, 'gym_name_excludes', data))
 
         # Slots Available
         self.min_slots = self.evaluate_attribute(

--- a/PokeAlarm/Filters/RaidFilter.py
+++ b/PokeAlarm/Filters/RaidFilter.py
@@ -72,6 +72,11 @@ class RaidFilter(BaseFilter):
             event_attribute='gym_name', eval_func=GymUtils.match_regex_dict,
             limit=BaseFilter.parse_as_set(
                 GymUtils.create_regex, 'gym_name_contains', data))
+        self.gym_name_excludes = self.evaluate_attribute(  # f.gn no-match e.gn
+            event_attribute='gym_name',
+            eval_func=GymUtils.not_match_regex_dict,
+            limit=BaseFilter.parse_as_set(
+                GymUtils.create_regex, 'gym_name_excludes', data))
 
         # Team Info
         self.old_team = self.evaluate_attribute(  # f.ctis contains m.cti

--- a/PokeAlarm/Utilities/GymUtils.py
+++ b/PokeAlarm/Utilities/GymUtils.py
@@ -43,3 +43,12 @@ def match_regex_dict(reg_exs, name):
         if reg_ex.search(name):
             return True
     return False
+
+
+# Returns true if the string does not match any given RE objects
+def not_match_regex_dict(reg_exs, name):
+    name = unicode(name)
+    for reg_ex in reg_exs:
+        if reg_ex.search(name):
+            return False
+    return True

--- a/tests/filters/test_egg_filter.py
+++ b/tests/filters/test_egg_filter.py
@@ -58,6 +58,21 @@ class TestEggFilter(unittest.TestCase):
         for e in [fail1, fail2, fail3]:
             self.assertFalse(egg_filter.check_event(e))
 
+    def test_gym_name_excludes(self):
+        # Create the filters
+        settings = {"gym_name_excludes": ["fail"]}
+        egg_filter = Filters.EggFilter('filter1', settings)
+
+        # Generate events that should pass
+        for r in ["pass1", "2pass", "3pass3"]:
+            event = Events.EggEvent(generate_egg({"name": r}))
+            self.assertTrue(egg_filter.check_event(event))
+
+        # Generate events that should fail
+        for r in ["fail1", "failpass", "passfail"]:
+            event = Events.EggEvent(generate_egg({"name": r}))
+            self.assertFalse(egg_filter.check_event(event))
+
     def test_current_team(self):
         # Create the filters
         settings = {"current_teams": [1, "2", "Instinct"]}

--- a/tests/filters/test_gym_filter.py
+++ b/tests/filters/test_gym_filter.py
@@ -33,6 +33,21 @@ class TestGymFilter(unittest.TestCase):
         for e in [fail1, fail2, fail3]:
             self.assertFalse(gym_filter.check_event(e))
 
+    def test_gym_name_excludes(self):
+        # Create the filters
+        settings = {"gym_name_excludes": ["fail"]}
+        gym_filter = Filters.GymFilter('filter1', settings)
+
+        # Generate events that should pass
+        for r in ["pass1", "2pass", "3pass3"]:
+            event = Events.GymEvent(generate_gym({"name": r}))
+            self.assertTrue(gym_filter.check_event(event))
+
+        # Generate events that should fail
+        for r in ["fail1", "failpass", "passfail"]:
+            event = Events.GymEvent(generate_gym({"name": r}))
+            self.assertFalse(gym_filter.check_event(event))
+
     def test_gym_guards(self):
         # Create the filters
         settings = {"min_slots": 2, "max_slots": 4}

--- a/tests/filters/test_raid_filter.py
+++ b/tests/filters/test_raid_filter.py
@@ -122,6 +122,21 @@ class TestRaidFilter(unittest.TestCase):
         for e in [fail1, fail2, fail3]:
             self.assertFalse(raid_filter.check_event(e))
 
+    def test_gym_name_excludes(self):
+        # Create the filters
+        settings = {"gym_name_excludes": ["fail"]}
+        raid_filter = Filters.RaidFilter('filter1', settings)
+
+        # Generate events that should pass
+        for r in ["pass1", "2pass", "3pass3"]:
+            event = Events.RaidEvent(generate_raid({"name": r}))
+            self.assertTrue(raid_filter.check_event(event))
+
+        # Generate events that should fail
+        for r in ["fail1", "failpass", "passfail"]:
+            event = Events.RaidEvent(generate_raid({"name": r}))
+            self.assertFalse(raid_filter.check_event(event))
+
     def test_current_team(self):
         # Create the filters
         settings = {"current_teams": [1, "2", "Instinct"]}


### PR DESCRIPTION
## Description
This adds in a new filter to Gym, Egg and Raid Events that is the exact opposite of the current `gym_name_contains` filter. 

Allows for using regex patterns to filter out events where the `gym_name` matches one of the given patterns resulting in a rejected event. 

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
This was requested via #585 

## How Has This Been Tested?
This was locally tested and has functional unit tests

## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change to https://github.com/RocketMap/PokeAlarmWiki.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [x] This change requires an update to the Wiki.
- [ ] This change does not require an update to the Wiki.


## Checklist
- [x] This change follows the code style of this project.
- [x] This change only changes what is necessary to the feature.
