### PR TITLE
Added geofence to rules

### DIFF
--- a/PokeAlarm/Load.py
+++ b/PokeAlarm/Load.py
@@ -72,7 +72,8 @@ def load_rules_section(set_rule, rules):
 
         filters = settings.pop('filters')
         alarms = settings.pop('alarms')
-        set_rule(name, filters, alarms)
+        geofences = settings.pop('geofences', None)
+        set_rule(name, filters, alarms, geofences)
 
         if len(settings) > 0:
             raise ValueError("Rule {} has unknown parameters: {}".format(

--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -539,6 +539,7 @@ class Manager(object):
 
         for r_name, rule in rules.iteritems():  # For all rules
             if not self.check_rule_geofences(rule, mon):
+                log.debug("Pokemon %s not in geofence, skipped", mon.name)
                 continue
             for f_name in rule.filter_names:  # Check Filters in Rules
                 f = self.__mon_filters.get(f_name)
@@ -621,6 +622,7 @@ class Manager(object):
 
         for r_name, rule in rules.iteritems():  # For all rules
             if not self.check_rule_geofences(rule, stop):
+                log.debug("Stop %s not in geofence, skipped", stop.stop_id)
                 continue
             for f_name in rule.filter_names:  # Check Filters in Rules
                 f = self.__stop_filters.get(f_name)
@@ -704,6 +706,7 @@ class Manager(object):
 
         for r_name, rule in rules.iteritems():  # For all rules
             if not self.check_rule_geofences(rule, gym):
+                log.debug("Gym %s not in geofence, skipped", gym.gym_id)
                 continue
             for f_name in rule.filter_names:  # Check Filters in Rules
                 f = self.__gym_filters.get(f_name)
@@ -791,6 +794,7 @@ class Manager(object):
 
         for r_name, rule in rules.iteritems():  #
             if not self.check_rule_geofences(rule, egg):
+                log.debug("Egg %s not in geofence, skipped", egg.gym_id)
                 continue
             #  For all rules
             for f_name in rule.filter_names:  # Check Filters in Rules
@@ -879,6 +883,7 @@ class Manager(object):
 
         for r_name, rule in rules.iteritems():  # For all rules
             if not self.check_rule_geofences(rule, raid):
+                log.debug("Raid %s not in geofence, skipped", raid.name)
                 continue
             for f_name in rule.filter_names:  # Check Filters in Rules
                 f = self.__raid_filters.get(f_name)
@@ -918,7 +923,9 @@ class Manager(object):
         for thread in threads:  # Wait for all alarms to finish
             thread.join()
 
-    def __check_fence(self, targets, e):
+    def _check_fence(self, targets, e):
+        if len(targets) == 1 and "all" in targets:
+            targets = self.geofences.iterkeys()
         for name in targets:
             gf = self.geofences.get(name)
             if not gf:  # gf doesn't exist
@@ -938,9 +945,7 @@ class Manager(object):
         if self.geofences is None or rule.geofence_names is None:
             return True
         targets = rule.geofence_names
-        if len(targets) == 1 and "all" in targets:
-            targets = self.geofences.iterkeys()
-        return self.__check_fence(targets, e)
+        return self._check_fence(targets, e)
 
     # Check to see if a notification is within the given range
     def check_geofences(self, f, e):
@@ -948,9 +953,7 @@ class Manager(object):
         if self.geofences is None or f.geofences is None:  # No geofences set
             return True
         targets = f.geofences
-        if len(targets) == 1 and "all" in targets:
-            targets = self.geofences.iterkeys()
-        if self.__check_fence(targets, e):
+        if self._check_fence(targets, e):
             return True
         f.reject(e, "not in geofences")
         return False

--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -183,7 +183,7 @@ class Manager(object):
 
         for gf in geofences:
             if gf not in self.geofences:
-                raise ValueError("Unable to create Rule: No Alarm "
+                raise ValueError("Unable to create Rule: No Geofence "
                                  "named {}!".format(gf))
 
         self.__mon_rules[name] = Rule(filters, alarms, geofences)
@@ -206,7 +206,7 @@ class Manager(object):
 
         for gf in geofences:
             if gf not in self.geofences:
-                raise ValueError("Unable to create Rule: No Alarm "
+                raise ValueError("Unable to create Rule: No Geofence "
                                  "named {}!".format(gf))
 
         self.__stop_rules[name] = Rule(filters, alarms, geofences)
@@ -229,7 +229,7 @@ class Manager(object):
 
         for gf in geofences:
             if gf not in self.geofences:
-                raise ValueError("Unable to create Rule: No Alarm "
+                raise ValueError("Unable to create Rule: No Geofence "
                                  "named {}!".format(gf))
 
         self.__gym_rules[name] = Rule(filters, alarms, geofences)
@@ -252,7 +252,7 @@ class Manager(object):
 
         for gf in geofences:
             if gf not in self.geofences:
-                raise ValueError("Unable to create Rule: No Alarm "
+                raise ValueError("Unable to create Rule: No Geofence "
                                  "named {}!".format(gf))
 
         self.__egg_rules[name] = Rule(filters, alarms, geofences)
@@ -275,7 +275,7 @@ class Manager(object):
 
         for gf in geofences:
             if gf not in self.geofences:
-                raise ValueError("Unable to create Rule: No Alarm "
+                raise ValueError("Unable to create Rule: No Geofence "
                                  "named {}!".format(gf))
 
         self.__raid_rules[name] = Rule(filters, alarms, geofences)

--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -935,7 +935,7 @@ class Manager(object):
     # Check to see if a notification is within the given range
     def check_rule_geofences(self, rule, e):
         """ Returns true if the event passes the filter's geofences. """
-        if self.geofences is None or rule.geofence_names is None:  # No geofences set
+        if self.geofences is None or rule.geofence_names is None:
             return True
         targets = rule.geofence_names
         if len(targets) == 1 and "all" in targets:


### PR DESCRIPTION
## Description
Allows rules to further sub-partition filter interpretations with geofence references.

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
 Let's say you
have a "candy" filter that selects high-value candy. You want this
to notify to different channels for different parts of your city.

Attaching geofences to rules makes this easy. It also adds a number of
other options for handling multiple configurations.

## How Has This Been Tested?
Tested locally with monsters, eggs and raids

## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change to https://github.com/RocketMap/PokeAlarmWiki.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [X] This change requires an update to the Wiki.
- [ ] This change does not require an update to the Wiki.


## Checklist
- [X] This change follows the code style of this project.
- [ ] This change only changes what is necessary to the feature.
