### PR TITLE
Fixed is_sponsor filter for Raids

### DIFF
--- a/PokeAlarm/Filters/RaidFilter.py
+++ b/PokeAlarm/Filters/RaidFilter.py
@@ -79,7 +79,7 @@ class RaidFilter(BaseFilter):
                 GymUtils.create_regex, 'gym_name_excludes', data))
 
         # Gym sponsor
-        self.is_sponsor = self.evaluate_attribute(  # f.gym_is_sponsor True
+        self.is_sponsor = self.evaluate_attribute(  # f.is_sponsor True
             event_attribute='is_sponsor', eval_func=operator.eq,
             limit=BaseFilter.parse_as_type(bool, 'is_sponsor', data))
 
@@ -147,8 +147,8 @@ class RaidFilter(BaseFilter):
             settings['gym_name_excludes'] = self.gym_name_excludes
 
         # Gym Sponsor
-        if self.gym_is_sponsor is not None:
-            settings['gym_is_sponsor'] = self.gym_is_sponsor
+        if self.is_sponsor is not None:
+            settings['is_sponsor'] = self.is_sponsor
 
         # Gym Park
         if self.park_contains is not None:


### PR DESCRIPTION
## Description
This corrects a bug with RaidFilter that causes a parsing error at startup. 

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
Fixes a bug that stops PA from loading if using Raid Filters

## How Has This Been Tested?
Tested on my production environment

## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change to https://github.com/RocketMap/PokeAlarmWiki.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [ ] This change requires an update to the Wiki.
- [x] This change does not require an update to the Wiki.


## Checklist
- [x] This change follows the code style of this project.
- [x] This change only changes what is necessary to the feature.
