### PR TITLE
Dev Add new DTSs for Height and Weight

### DIFF
--- a/PokeAlarm/Events/MonEvent.py
+++ b/PokeAlarm/Events/MonEvent.py
@@ -259,7 +259,7 @@ class MonEvent(BaseEvent):
             'height_2': (
                 "{:.2f}".format(self.height) if Unknown.is_not(self.height)
                 else Unknown.SMALL),
-            'hweight_0': (
+            'weight_0': (
                 "{:.0f}".format(self.weight) if Unknown.is_not(self.weight)
                 else Unknown.TINY),
             'weight': (

--- a/PokeAlarm/Events/MonEvent.py
+++ b/PokeAlarm/Events/MonEvent.py
@@ -250,9 +250,24 @@ class MonEvent(BaseEvent):
 
             # Cosmetic
             'gender': self.gender,
-            'height': self.height,
-            'weight': self.weight,
-            'weight_short': "{:.1f}".format(self.weight),
+            'height_0': (
+                "{:.0f}".format(self.height) if Unknown.is_not(self.height)
+                else Unknown.TINY),
+            'height': (
+                "{:.1f}".format(self.height) if Unknown.is_not(self.height)
+                else Unknown.SMALL),
+            'height_2': (
+                "{:.2f}".format(self.height) if Unknown.is_not(self.height)
+                else Unknown.SMALL),
+            'hweight_0': (
+                "{:.0f}".format(self.weight) if Unknown.is_not(self.weight)
+                else Unknown.TINY),
+            'weight': (
+                "{:.1f}".format(self.weight) if Unknown.is_not(self.weight)
+                else Unknown.SMALL),
+            'weight_2': (
+                "{:.2f}".format(self.weight) if Unknown.is_not(self.weight)
+                else Unknown.SMALL),
             'size': locale.get_size_name(self.size_id),
 
             # Attack rating

--- a/PokeAlarm/Events/MonEvent.py
+++ b/PokeAlarm/Events/MonEvent.py
@@ -252,6 +252,7 @@ class MonEvent(BaseEvent):
             'gender': self.gender,
             'height': self.height,
             'weight': self.weight,
+            'weight_short': "{:.1f}".format(self.weight),
             'size': locale.get_size_name(self.size_id),
 
             # Attack rating

--- a/docs/configuration/events/monster-events.rst
+++ b/docs/configuration/events/monster-events.rst
@@ -136,8 +136,11 @@ costume_id          Costume ID of the monster.
 costume_id_3        Costume ID of the monster, formatted to there digits.
 gender              Gender of the monster, represented as a single character.
 height              Height of the monster.
+height_0            Height of the monster, rounded to the nearest integer. 
+height_2            Height of the monster, rounded to 2 decimal places. 
 weight              Weight of the monster.
-weight_short        Weight of the monster, truncated to 1 decimal place.
+weight_0            Weight of the monster, rounded to the nearest integer. 
+weight_2            Weight of the monster, rounded to 2 decimal places. 
 size                Estimated size of the monster.
 big_karp            Return `big` if Magikarp weight is >=13.13.
 tiny_rat            Return `tiny` if Rattata weight is <=2.41.

--- a/docs/configuration/events/monster-events.rst
+++ b/docs/configuration/events/monster-events.rst
@@ -137,6 +137,7 @@ costume_id_3        Costume ID of the monster, formatted to there digits.
 gender              Gender of the monster, represented as a single character.
 height              Height of the monster.
 weight              Weight of the monster.
+weight_short        Weight of the monster, truncated to 1 decimal places.
 size                Estimated size of the monster.
 big_karp            Return `big` if Magikarp weight is >=13.13.
 tiny_rat            Return `tiny` if Rattata weight is <=2.41.

--- a/docs/configuration/events/monster-events.rst
+++ b/docs/configuration/events/monster-events.rst
@@ -137,7 +137,7 @@ costume_id_3        Costume ID of the monster, formatted to there digits.
 gender              Gender of the monster, represented as a single character.
 height              Height of the monster.
 weight              Weight of the monster.
-weight_short        Weight of the monster, truncated to 1 decimal places.
+weight_short        Weight of the monster, truncated to 1 decimal place.
 size                Estimated size of the monster.
 big_karp            Return `big` if Magikarp weight is >=13.13.
 tiny_rat            Return `tiny` if Rattata weight is <=2.41.


### PR DESCRIPTION
<!--       PULL REQUESTS CREATED NOT USING ONE OF THE BELOW         --->
<!--      ISSUE TEMPLATES WILL BE CLOSED WITHOUT ANY RESPONSE       --->
<!--       PULL REQUESTS CREATED NOT USING ONE OF THE BELOW         --->
<!--      ISSUE TEMPLATES WILL BE CLOSED WITHOUT ANY RESPONSE       --->
<!--       PULL REQUESTS CREATED NOT USING ONE OF THE BELOW         --->
<!--      ISSUE TEMPLATES WILL BE CLOSED WITHOUT ANY RESPONSE       --->
<!--       PULL REQUESTS CREATED NOT USING ONE OF THE BELOW         --->
<!--      ISSUE TEMPLATES WILL BE CLOSED WITHOUT ANY RESPONSE       --->


<!--
 Please make all PRs to the dev branch. The dev branch will be
 periodically pulled into the master branch. This allows time for
 the changes and documentation to be tested before being exposed to
 a wider population.
--->

## Description
Add addtional weight & height DTSs matching IV style, with 0,1 & 2 decimals

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
<!---
weight/height returns "infinite" decimals the way it's set up today, making it less used
-->

## How Has This Been Tested?
<!---
Tested on my own setup with discord alarms
-->

## Screenshots (if appropriate):


## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change to https://github.com/RocketMap/PokeAlarmWiki.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [x] This change requires an update to the Wiki.
- [ ] This change does not require an update to the Wiki.


## Checklist
- [x] This change follows the code style of this project.
- [x] This change only changes what is necessary to the feature.
