### PR TITLE
[WIP] Quest Events

### DIFF
--- a/PokeAlarm/Alarms/Alarm.py
+++ b/PokeAlarm/Alarms/Alarm.py
@@ -64,6 +64,10 @@ class Alarm(object):
     def weather_alert(self, pokeweather_info):
         raise NotImplementedError('Weather Alert is not implemented.')
 
+    # Trigger an alert when a quest is reported
+    def quest_alert(self, pokequest_info):
+        raise NotImplementedError('Quest Alert is not implemented.')
+
     # Return a version of the string with the correct substitutions made
     @staticmethod
     def replace(string, pkinfo):

--- a/PokeAlarm/Alarms/Discord/DiscordAlarm.py
+++ b/PokeAlarm/Alarms/Discord/DiscordAlarm.py
@@ -81,11 +81,11 @@ class DiscordAlarm(Alarm):
             "url": "<gmaps>",
             "body": "The weather around <lat>,<lng> has changed to <weather>!"
         },
-        'quest': {
+        'quests': {
             'username': "Quest",
             'content': "",
-            'icon_url': None,
-            'avatar_url': None,
+            'icon_url': get_image_url("regular/quest/<type_id>.png"),
+            'avatar_url': get_image_url("regular/quest/<type_id>.png"),
             'title': "New Quest Found!",
             'url': "<gmaps>",
             'body': "Quest will expire at midnight."
@@ -122,8 +122,8 @@ class DiscordAlarm(Alarm):
             settings.pop('raids', {}), self._defaults['raids'])
         self.__weather = self.create_alert_settings(
             settings.pop('weather', {}), self._defaults['weather'])
-        self.__quest = self.create_alert_settings(
-            settings.pop('quest', {}), self._defaults['quest'])
+        self.__quests = self.create_alert_settings(
+            settings.pop('quests', {}), self._defaults['quests'])
 
         # Warn user about leftover parameters
         reject_leftover_parameters(settings, "'Alarm level in Discord alarm.")
@@ -230,7 +230,7 @@ class DiscordAlarm(Alarm):
 
     def quest_alert(self, quest_info):
         self._log.debug("Quest notification triggered.")
-        self.send_alert(self.__quest, quest_info)
+        self.send_alert(self.__quests, quest_info)
 
     # Send a payload to the webhook url
     def send_webhook(self, url, payload):

--- a/PokeAlarm/Alarms/Discord/DiscordAlarm.py
+++ b/PokeAlarm/Alarms/Discord/DiscordAlarm.py
@@ -88,7 +88,7 @@ class DiscordAlarm(Alarm):
             'avatar_url': get_image_url("regular/quest/<type_id>.png"),
             'title': "New Quest Found!",
             'url': "<gmaps>",
-            'body': "Quest will expire at midnight."
+            'body': "Quest will expire in <time_remaining>"
         }
     }
 

--- a/PokeAlarm/Alarms/Discord/DiscordAlarm.py
+++ b/PokeAlarm/Alarms/Discord/DiscordAlarm.py
@@ -80,6 +80,15 @@ class DiscordAlarm(Alarm):
             "title": "The weather has changed!",
             "url": "<gmaps>",
             "body": "The weather around <lat>,<lng> has changed to <weather>!"
+        },
+        'quest': {
+            'username': "Quest",
+            'content': "",
+            'icon_url': None,
+            'avatar_url': None,
+            'title': "New Quest Found!",
+            'url': "<gmaps>",
+            'body': "Quest will expire at midnight."
         }
     }
 
@@ -113,6 +122,8 @@ class DiscordAlarm(Alarm):
             settings.pop('raids', {}), self._defaults['raids'])
         self.__weather = self.create_alert_settings(
             settings.pop('weather', {}), self._defaults['weather'])
+        self.__quest = self.create_alert_settings(
+            settings.pop('quest', {}), self._defaults['quest'])
 
         # Warn user about leftover parameters
         reject_leftover_parameters(settings, "'Alarm level in Discord alarm.")
@@ -205,14 +216,21 @@ class DiscordAlarm(Alarm):
 
     # Trigger an alert when a raid egg has spawned (UPCOMING raid event)
     def raid_egg_alert(self, raid_info):
+        self._log.debug("Raid Egg notification triggered.")
         self.send_alert(self.__eggs, raid_info)
 
     def raid_alert(self, raid_info):
+        self._log.debug("Raid notification triggered.")
         self.send_alert(self.__raids, raid_info)
 
     # Trigger an alert based on Weather info
     def weather_alert(self, weather_info):
+        self._log.debug("Weather notification triggered.")
         self.send_alert(self.__weather, weather_info)
+
+    def quest_alert(self, quest_info):
+        self._log.debug("Quest notification triggered.")
+        self.send_alert(self.__quest, quest_info)
 
     # Send a payload to the webhook url
     def send_webhook(self, url, payload):

--- a/PokeAlarm/Alarms/FacebookPage/FacebookPageAlarm.py
+++ b/PokeAlarm/Alarms/FacebookPage/FacebookPageAlarm.py
@@ -79,12 +79,11 @@ class FacebookPageAlarm(Alarm):
             'caption': None
         },
         'quests': {
-            'message': "*New quest for <reward>*\n"
-                       "<quest>",
+            'message': "*New quest for <reward>*",
             'image': get_image_url('regular/quest/<type_id>.png'),
             'link': '<gmaps>',
             'name': 'Quest',
-            'description': 'New quest for <reward>\n<quest>',
+            'description': '<quest>',
             'caption': None
         }
     }

--- a/PokeAlarm/Alarms/FacebookPage/FacebookPageAlarm.py
+++ b/PokeAlarm/Alarms/FacebookPage/FacebookPageAlarm.py
@@ -77,6 +77,15 @@ class FacebookPageAlarm(Alarm):
             'description': "The weather around <lat>,<lng>"
                            " has changed to <weather>!",
             'caption': None
+        },
+        'quests': {
+            'message': "*New quest for <reward>*\n"
+                       "<quest>",
+            'image': get_image_url('regular/quest/<type_id>.png'),
+            'link': '<gmaps>',
+            'name': 'Quest',
+            'description': 'New quest for <reward>\n<quest>',
+            'caption': None
         }
     }
 
@@ -106,6 +115,8 @@ class FacebookPageAlarm(Alarm):
             settings.pop('raids', {}), self._defaults['raids'])
         self.__weather = self.create_alert_settings(
             settings.pop('weather', {}), self._defaults['weather'])
+        self.__quests = self.create_alert_settings(
+            settings.pop('quests', {}), self._defaults['quests'])
 
         #  Warn user about leftover parameters
         reject_leftover_parameters(
@@ -178,6 +189,10 @@ class FacebookPageAlarm(Alarm):
     # Trigger an alert based on Weather info
     def weather_alert(self, weather_info):
         self.send_alert(self.__weather, weather_info)
+
+    # Quest Alert
+    def quest_alert(self, quest_info):
+        self.send_alert(self.__quests, quest_info)
 
     # Sends a wall post to Facebook
     def post_to_wall(self, message, attachment=None):

--- a/PokeAlarm/Alarms/Pushbullet/PushBulletAlarm.py
+++ b/PokeAlarm/Alarms/Pushbullet/PushBulletAlarm.py
@@ -52,10 +52,9 @@ class PushbulletAlarm(Alarm):
             'body': "The weather around <lat>,<lng> has changed to <weather>!"
         },
         'quests': {
-            'message': "*New quest for <reward>*\n"
-                       "<quest>",
+            'title': '*New quest for <reward>*',
             'url': '<gmaps>',
-            'body': 'New quest for <reward>\n<quest>'
+            'body': '<quest>'
         }
     }
 

--- a/PokeAlarm/Alarms/Pushbullet/PushBulletAlarm.py
+++ b/PokeAlarm/Alarms/Pushbullet/PushBulletAlarm.py
@@ -50,6 +50,12 @@ class PushbulletAlarm(Alarm):
             'title': "The weather has changed!",
             'url': "<gmaps>",
             'body': "The weather around <lat>,<lng> has changed to <weather>!"
+        },
+        'quests': {
+            'message': "*New quest for <reward>*\n"
+                       "<quest>",
+            'url': '<gmaps>',
+            'body': 'New quest for <reward>\n<quest>'
         }
     }
 
@@ -81,6 +87,8 @@ class PushbulletAlarm(Alarm):
             settings.pop('raids', {}), self._defaults['raids'])
         self.__weather = self.create_alert_settings(
             settings.pop('weather', {}), self._defaults['weather'])
+        self.__quest = self.create_alert_settings(
+            settings.pop('quests', {}), self._defaults['quests'])
 
         #  Warn user about leftover parameters
         reject_leftover_parameters(
@@ -156,6 +164,10 @@ class PushbulletAlarm(Alarm):
     # Trigger an alert based on Weather info
     def weather_alert(self, weather_info):
         self.send_alert(self.__weather, weather_info)
+
+    # Trigger quest alert
+    def quest_alert(self, quest_info):
+        self.send_alert(self.__quest, quest_info)
 
     # Attempt to get the channel, otherwise default to all devices
     def get_sender(self, channel_tag):

--- a/PokeAlarm/Alarms/Slack/SlackAlarm.py
+++ b/PokeAlarm/Alarms/Slack/SlackAlarm.py
@@ -68,6 +68,13 @@ class SlackAlarm(Alarm):
             'title': "The weather has changed!",
             'url': "<gmaps>",
             'body': "The weather around <lat>,<lng> has changed to <weather>!"
+        },
+        'quests': {
+            'username': "Quest",
+            'icon_url': get_image_url("regular/quest/<type_id>.png"),
+            'title': "New Quest Found!",
+            'url': "<gmaps>",
+            'body': "Quest will expire at midnight."
         }
     }
 
@@ -102,6 +109,8 @@ class SlackAlarm(Alarm):
             settings.pop('raids', {}), self._defaults['raids'])
         self.__weather = self.create_alert_settings(
             settings.pop('weather', {}), self._defaults['weather'])
+        self.__quests = self.create_alert_settings(
+            settings.pop('quests', {}), self._defaults['quests'])
 
         # Warn user about leftover parameters
         reject_leftover_parameters(settings, "'Alarm level in Slack alarm.")
@@ -178,6 +187,10 @@ class SlackAlarm(Alarm):
     # Trigger an alert based on Weather info
     def weather_alert(self, weather_info):
         self.send_alert(self.__weather, weather_info)
+
+    # Trigger quest alert
+    def quest_alert(self, quest_info):
+        self.send_alert(self.__quests, quest_info)
 
     # Get a list of channels from Slack to help
     def update_channels(self):

--- a/PokeAlarm/Alarms/Telegram/TelegramAlarm.py
+++ b/PokeAlarm/Alarms/Telegram/TelegramAlarm.py
@@ -63,6 +63,11 @@ class TelegramAlarm(Alarm):
                        " changed to <weather>!",
             'sticker_url': get_image_url(
                 "telegram/weather/<weather_id_3>_<day_or_night_id_3>.webp")
+        },
+        'quest': {
+            'message': "*New quest for <reward>*\n"
+                       "<quest>",
+            'sticker_url': get_image_url("telegram/stop/ready.webp")
         }
     }
 
@@ -116,6 +121,8 @@ class TelegramAlarm(Alarm):
             'raids', settings, alert_defaults)
         self._weather_alert = self.create_alert_settings(
             'weather', settings, alert_defaults)
+        self._quest_alert = self.create_alert_settings(
+            'quest', settings, alert_defaults)
 
         # Reject leftover parameters
         for key in settings:
@@ -233,6 +240,9 @@ class TelegramAlarm(Alarm):
     # Trigger an alert based on Weather info
     def weather_alert(self, weather_dts):
         self.generic_alert(self._weather_alert, weather_dts)
+
+    def quest_alert(self, quest_dts):
+        self.generic_alert(self._quest_alert, quest_dts)
 
     def send_sticker(self, token, chat_id, sticker_url,
                      max_attempts=3, notify=False):

--- a/PokeAlarm/Alarms/Telegram/TelegramAlarm.py
+++ b/PokeAlarm/Alarms/Telegram/TelegramAlarm.py
@@ -64,10 +64,10 @@ class TelegramAlarm(Alarm):
             'sticker_url': get_image_url(
                 "telegram/weather/<weather_id_3>_<day_or_night_id_3>.webp")
         },
-        'quest': {
+        'quests': {
             'message': "*New quest for <reward>*\n"
                        "<quest>",
-            'sticker_url': get_image_url("telegram/stop/ready.webp")
+            'sticker_url': get_image_url("telegram/quest/<type_id>.webp")
         }
     }
 
@@ -122,7 +122,7 @@ class TelegramAlarm(Alarm):
         self._weather_alert = self.create_alert_settings(
             'weather', settings, alert_defaults)
         self._quest_alert = self.create_alert_settings(
-            'quest', settings, alert_defaults)
+            'quests', settings, alert_defaults)
 
         # Reject leftover parameters
         for key in settings:

--- a/PokeAlarm/Alarms/Twilio/TwilioAlarm.py
+++ b/PokeAlarm/Alarms/Twilio/TwilioAlarm.py
@@ -45,6 +45,9 @@ class TwilioAlarm(Alarm):
         'weather': {
             'message': "The weather around <lat>,<lng> has"
                        " changed to <weather>!"
+        },
+        'quests': {
+            'message': "*New quest for <reward>*\n<quest>\n<gmaps>",
         }
     }
 
@@ -80,6 +83,8 @@ class TwilioAlarm(Alarm):
             settings.pop('raids', {}), self._defaults['raids'])
         self.__weather = self.set_alert(
             settings.pop('weather', {}), self._defaults['weather'])
+        self.__quest = self.set_alert(
+            settings.pop('quests', {}), self._defaults['quests'])
 
         # Warn user about leftover parameters
         reject_leftover_parameters(settings, "'Alarm level in Twilio alarm.")
@@ -141,6 +146,10 @@ class TwilioAlarm(Alarm):
     # Trigger an alert based on Weather info
     def weather_alert(self, weather_info):
         self.send_alert(self.__weather, weather_info)
+
+    # Trigger an alert based on Weather info
+    def quest_alert(self, quest_info):
+        self.send_alert(self.__quest, quest_info)
 
     # Send a SMS message
     def send_sms(self, to_num, from_num, body):

--- a/PokeAlarm/Alarms/Twitter/TwitterAlarm.py
+++ b/PokeAlarm/Alarms/Twitter/TwitterAlarm.py
@@ -50,6 +50,9 @@ class TwitterAlarm(Alarm):
         'weather': {
             'status': "The weather around <lat>,<lng> has changed"
                       " to <weather>!"
+        },
+        'quests': {
+            'status': "*New quest for <reward>*\n<quest>\n<gmaps>",
         }
     }
 
@@ -85,6 +88,8 @@ class TwitterAlarm(Alarm):
             settings.pop('raids', {}), self._defaults['raids'])
         self.__weather = self.create_alert_settings(
             settings.pop('weather', {}), self._defaults['weather'])
+        self.__quest = self.create_alert_settings(
+            settings.pop('quests', {}), self._defaults['quests'])
 
         # Warn user about leftover parameters
         reject_leftover_parameters(settings, "'Alarm level in Twitter alarm.")
@@ -163,6 +168,10 @@ class TwitterAlarm(Alarm):
     # Trigger an alert based on weather webhook
     def weather_alert(self, weather_info):
         self.send_alert(self.__weather, weather_info)
+
+    # Trigger an alert based on weather webhook
+    def quest_alert(self, quest_info):
+        self.send_alert(self.__quest, quest_info)
 
     # Send out a tweet with the given status
     def send_tweet(self, status):

--- a/PokeAlarm/Cache/Cache.py
+++ b/PokeAlarm/Cache/Cache.py
@@ -23,6 +23,7 @@ class Cache(object):
         self._stop_hist = {}
         self._egg_hist = {}
         self._raid_hist = {}
+        self._quest_hist = {}
         self._gym_team = {}
         self._gym_name = {}
         self._gym_desc = {}
@@ -31,6 +32,7 @@ class Cache(object):
         self._severity_id = {}
         self._day_or_night_id = {}
         self._reward = {}
+        self._task = {}
 
     def monster_expiration(self, mon_id, expiration=None):
         """ Update and return the datetime that a monster expires."""
@@ -55,6 +57,12 @@ class Cache(object):
         if expiration is not None:
             self._raid_hist[raid_id] = expiration
         return self._raid_hist.get(raid_id)
+
+    def quest_expiration(self, stop_id, expiration=None):
+        """ Update and return the datetime that a quest expires."""
+        if expiration is not None:
+            self._quest_hist[stop_id] = expiration
+        return self._quest_hist.get(stop_id)
 
     def gym_team(self, gym_id, team_id=Unknown.TINY):
         """ Update and return the team_id of a gym. """
@@ -98,11 +106,14 @@ class Cache(object):
             self._day_or_night_id[s2_cell_id] = day_or_night_id
         return self._day_or_night_id.get(s2_cell_id, Unknown.REGULAR)
 
-    def quest_reward(self, stop_id, reward=None):
-        """ Update and return the reward for a quest."""
+    def quest_reward(self, stop_id, reward=None, task=None):
+        """ Update and return the reward and task for a quest."""
         if Unknown.is_not(reward):
             self._reward[stop_id] = reward
-        return self._reward.get(stop_id, Unknown.REGULAR)
+        if Unknown.is_not(task):
+            self._task[stop_id] = task
+        return self._reward.get(stop_id, Unknown.REGULAR), \
+            self._task.get(stop_id, Unknown.REGULAR)
 
     def clean_and_save(self):
         """ Cleans the cache and saves the contents if capable. """
@@ -117,7 +128,7 @@ class Cache(object):
         """ Clean expired objects to free up memory. """
         for hist in (
                 self._mon_hist, self._stop_hist, self._egg_hist,
-                self._raid_hist):
+                self._raid_hist, self._quest_hist):
             old = []
             now = datetime.utcnow()
             for key, expiration in hist.iteritems():

--- a/PokeAlarm/Cache/Cache.py
+++ b/PokeAlarm/Cache/Cache.py
@@ -30,6 +30,7 @@ class Cache(object):
         self._cell_weather_id = {}
         self._severity_id = {}
         self._day_or_night_id = {}
+        self._reward = {}
 
     def monster_expiration(self, mon_id, expiration=None):
         """ Update and return the datetime that a monster expires."""
@@ -96,6 +97,12 @@ class Cache(object):
         if Unknown.is_not(day_or_night_id):
             self._day_or_night_id[s2_cell_id] = day_or_night_id
         return self._day_or_night_id.get(s2_cell_id, Unknown.REGULAR)
+
+    def quest_reward(self, stop_id, reward=None):
+        """ Update and return the reward for a quest."""
+        if Unknown.is_not(reward):
+            self._reward[stop_id] = reward
+        return self._reward.get(stop_id, Unknown.REGULAR)
 
     def clean_and_save(self):
         """ Cleans the cache and saves the contents if capable. """

--- a/PokeAlarm/Cache/FileCache.py
+++ b/PokeAlarm/Cache/FileCache.py
@@ -43,6 +43,7 @@ class FileCache(Cache):
                 self._severity_id = data.get('severity_id', {})
                 self._day_or_night_id = data.get('day_or_night_id', {})
                 self._reward = data.get('reward', {})
+                self._task = data.get('task', {})
 
                 self._log.debug("Cache loaded successfully.")
         except Exception as e:
@@ -66,7 +67,8 @@ class FileCache(Cache):
             'cell_weather_id': self._cell_weather_id,
             'severity_id': self._severity_id,
             'day_or_night_id': self._day_or_night_id,
-            'reward': self._reward
+            'reward': self._reward,
+            'task': self._task
         }
         try:
             # Write to temporary file and then rename

--- a/PokeAlarm/Cache/FileCache.py
+++ b/PokeAlarm/Cache/FileCache.py
@@ -42,6 +42,7 @@ class FileCache(Cache):
                 self._cell_weather_id = data.get('cell_weather_id', {})
                 self._severity_id = data.get('severity_id', {})
                 self._day_or_night_id = data.get('day_or_night_id', {})
+                self._reward = data.get('reward', {})
 
                 self._log.debug("Cache loaded successfully.")
         except Exception as e:
@@ -64,7 +65,8 @@ class FileCache(Cache):
             'gym_image': self._gym_image,
             'cell_weather_id': self._cell_weather_id,
             'severity_id': self._severity_id,
-            'day_or_night_id': self._day_or_night_id
+            'day_or_night_id': self._day_or_night_id,
+            'reward': self._reward
         }
         try:
             # Write to temporary file and then rename

--- a/PokeAlarm/Events/QuestEvent.py
+++ b/PokeAlarm/Events/QuestEvent.py
@@ -1,0 +1,66 @@
+# Standard Library Imports
+import datetime
+# 3rd Party Imports
+# Local Imports
+from PokeAlarm import Unknown
+from . import BaseEvent
+from PokeAlarm.Utils import get_gmaps_link, get_applemaps_link, \
+    get_dist_as_str
+
+
+class QuestEvent(BaseEvent):
+    """ Event representing the discovery of a PokeStop. """
+
+    def __init__(self, data):
+        """ Creates a new Quest Event based on the given dict. """
+        super(QuestEvent, self).__init__('quest')
+
+        # Identification
+        self.stop_id = data['pokestop_id']
+        self.stop_name = data['name']
+        self.stop_image = data['url']
+
+        # Location
+        self.lat = float(data['latitude'])
+        self.lng = float(data['longitude'])
+
+        # Completed by Manager
+        self.distance = Unknown.SMALL
+        self.direction = Unknown.TINY
+
+        # Used to reject
+        self.name = self.stop_id
+        self.geofence = Unknown.REGULAR
+        self.custom_dts = {}
+
+        # Quest Details
+        self.quest = data['quest']
+        self.reward = data['reward']
+        self.expiry = datetime.datetime.now().strftime("%d/%m/%Y 23:59")
+
+    def generate_dts(self, locale, timezone, units):
+        """ Return a dict with all the DTS for this event. """
+        dts = self.custom_dts.copy()
+        dts.update({
+            # Identification
+            'stop_id': self.stop_id,
+            'stop_name': self.stop_name,
+            'stop_image': self.stop_image,
+            # Location
+            'lat': self.lat,
+            'lng': self.lng,
+            'lat_5': "{:.5f}".format(self.lat),
+            'lng_5': "{:.5f}".format(self.lat),
+            'distance': (
+                get_dist_as_str(self.distance, units)
+                if Unknown.is_not(self.distance) else Unknown.SMALL),
+            'direction': self.direction,
+            'gmaps': get_gmaps_link(self.lat, self.lng),
+            'applemaps': get_applemaps_link(self.lat, self.lng),
+            'geofence': self.geofence,
+            # Quest Details
+            'quest': self.quest,
+            'reward': self.reward,
+            'expiry': self.expiry
+        })
+        return dts

--- a/PokeAlarm/Events/QuestEvent.py
+++ b/PokeAlarm/Events/QuestEvent.py
@@ -9,7 +9,7 @@ from PokeAlarm.Utils import get_gmaps_link, get_applemaps_link, \
 
 
 class QuestEvent(BaseEvent):
-    """ Event representing the discovery of a PokeStop. """
+    """ Event representing the discovery of a Quest. """
 
     def __init__(self, data):
         """ Creates a new Quest Event based on the given dict. """
@@ -40,12 +40,12 @@ class QuestEvent(BaseEvent):
         # Quest Details
         self.quest = data['quest']
         self.reward = data['reward']
-        self.expiry = datetime.datetime.now().strftime("%d/%m/%Y 23:59")
-        self.type = check_for_none(int, data.get('type'), 0)
+        self.expire_time = datetime.datetime.now().strftime("%d/%m/%Y 23:59")
+        self.reward_type = check_for_none(int, data.get('type'), 0)
 
     def generate_dts(self, locale, timezone, units):
         """ Return a dict with all the DTS for this event. """
-        type_name = locale.get_quest_type_name(self.type)
+        type_name = locale.get_quest_type_name(self.reward_type)
 
         dts = self.custom_dts.copy()
         dts.update({
@@ -53,8 +53,8 @@ class QuestEvent(BaseEvent):
             'stop_id': self.stop_id,
             'stop_name': self.stop_name,
             'stop_image': self.stop_image,
-            'type_id': self.type,
-            'type': type_name,
+            'reward_type_id': self.reward_type,
+            'reward_type': type_name,
             # Location
             'lat': self.lat,
             'lng': self.lng,
@@ -71,6 +71,7 @@ class QuestEvent(BaseEvent):
             # Quest Details
             'quest': self.quest,
             'reward': self.reward,
-            'expiry': self.expiry
+            'expire_time': self.expire_time,
+            'time_remaining': self.expire_time
         })
         return dts

--- a/PokeAlarm/Events/QuestEvent.py
+++ b/PokeAlarm/Events/QuestEvent.py
@@ -1,5 +1,5 @@
 # Standard Library Imports
-import datetime
+from datetime import datetime, time, date
 # 3rd Party Imports
 # Local Imports
 from PokeAlarm import Unknown
@@ -40,7 +40,12 @@ class QuestEvent(BaseEvent):
         # Quest Details
         self.quest = data['quest']
         self.reward = data['reward']
-        self.expire_time = datetime.datetime.now().strftime("%d/%m/%Y 23:59")
+        # To ensure Windows compatibility, epoch calculation is required
+        self.expire_time = datetime.utcfromtimestamp(
+            data.get(
+                'expire_time',
+                (datetime.combine(date.today(), time(23, 59)) -
+                 datetime(1970, 1, 1)).total_seconds()))
         self.reward_type = check_for_none(int, data.get('type'), 0)
 
     def generate_dts(self, locale, timezone, units):
@@ -71,7 +76,6 @@ class QuestEvent(BaseEvent):
             # Quest Details
             'quest': self.quest,
             'reward': self.reward,
-            'expire_time': self.expire_time,
-            'time_remaining': self.expire_time
+            'expire_time': self.expire_time
         })
         return dts

--- a/PokeAlarm/Events/QuestEvent.py
+++ b/PokeAlarm/Events/QuestEvent.py
@@ -19,9 +19,10 @@ class QuestEvent(BaseEvent):
         # Identification
         self.stop_id = data['pokestop_id']
         self.stop_name = check_for_none(
-            str, data.get('name'), Unknown.REGULAR)
+            str, data.get('pokestop_name') or data.get('name'),
+            Unknown.REGULAR)
         self.stop_image = check_for_none(
-            str, data.get('pokestop_url'), Unknown.REGULAR)
+            str, data.get('pokestop_url') or data.get('url'), Unknown.REGULAR)
 
         # Location
         self.lat = float(data['latitude'])
@@ -70,7 +71,6 @@ class QuestEvent(BaseEvent):
             # Quest Details
             'quest': self.quest,
             'reward': self.reward,
-            'reward_type': self.type,
             'expiry': self.expiry
         })
         return dts

--- a/PokeAlarm/Events/__init__.py
+++ b/PokeAlarm/Events/__init__.py
@@ -8,6 +8,7 @@ from GymEvent import GymEvent
 from EggEvent import EggEvent
 from RaidEvent import RaidEvent
 from WeatherEvent import WeatherEvent
+from QuestEvent import QuestEvent
 
 log = logging.getLogger('Events')
 
@@ -31,6 +32,8 @@ def event_factory(data):
             return RaidEvent(message)
         elif kind == 'weather':
             return WeatherEvent(message)
+        elif kind == 'quest':
+            return QuestEvent(message)
         elif kind in ['captcha', 'scheduler']:
             log.debug(
                 "{} data ignored - unsupported webhook type.".format(kind))

--- a/PokeAlarm/Filters/QuestFilter.py
+++ b/PokeAlarm/Filters/QuestFilter.py
@@ -1,0 +1,79 @@
+# Standard Library Imports
+import operator
+# 3rd Party Imports
+# Local Imports
+from . import BaseFilter
+from PokeAlarm.Utilities import GymUtils as GymUtils
+
+class QuestFilter(BaseFilter):
+    """ Filter class for limiting which quests trigger a notification. """
+
+    def __init__(self, mgr, name, data):
+        """ Initializes base parameters for a filter. """
+        super(QuestFilter, self).__init__(mgr, 'quest', name)
+
+        # Distance
+        self.min_dist = self.evaluate_attribute(  # f.min_dist <= m.distance
+            event_attribute='distance', eval_func=operator.le,
+            limit=BaseFilter.parse_as_type(float, 'min_dist', data))
+        self.max_dist = self.evaluate_attribute(  # f.max_dist <= m.distance
+            event_attribute='distance', eval_func=operator.ge,
+            limit=BaseFilter.parse_as_type(float, 'max_dist', data))
+            
+        # Quest Description
+        self.quest_contains = self.evaluate_attribute(  # f.gn matches e.gn
+            event_attribute='quest', eval_func=GymUtils.match_regex_dict,
+            limit=BaseFilter.parse_as_set(
+                GymUtils.create_regex, 'quest_contains', data))
+        self.gym_name_excludes = self.evaluate_attribute(  # f.gn no-match e.gn
+            event_attribute='quest',
+            eval_func=GymUtils.not_match_regex_dict,
+            limit=BaseFilter.parse_as_set(
+                GymUtils.create_regex, 'quest_excludes', data))
+                
+        # Reward Description
+        self.reward_contains = self.evaluate_attribute(  # f.gn matches e.gn
+            event_attribute='reward', eval_func=GymUtils.match_regex_dict,
+            limit=BaseFilter.parse_as_set(
+                GymUtils.create_regex, 'reward_contains', data))
+        self.gym_name_excludes = self.evaluate_attribute(  # f.gn no-match e.gn
+            event_attribute='reward',
+            eval_func=GymUtils.not_match_regex_dict,
+            limit=BaseFilter.parse_as_set(
+                GymUtils.create_regex, 'reward_excludes', data))
+
+        # Geofences
+        self.geofences = BaseFilter.parse_as_list(str, 'geofences', data)
+
+        # Custom DTS
+        self.custom_dts = BaseFilter.parse_as_dict(
+            str, str, 'custom_dts', data)
+
+        # Missing Info
+        self.is_missing_info = BaseFilter.parse_as_type(
+            bool, 'is_missing_info', data)
+
+        # Reject leftover parameters
+        for key in data:
+            raise ValueError("'{}' is not a recognized parameter for"
+                             " Stop filters".format(key))
+
+    def to_dict(self):
+        """ Create a dict representation of this Filter. """
+        settings = {}
+
+        # Distance
+        if self.min_dist is not None:
+            settings['min_dist'] = self.min_dist
+        if self.max_dist is not None:
+            settings['max_dist'] = self.max_dist
+
+        # Geofences
+        if self.geofences is not None:
+            settings['geofences'] = self.geofences
+
+        # Missing Info
+        if self.is_missing_info is not None:
+            settings['missing_info'] = self.is_missing_info
+
+        return settings

--- a/PokeAlarm/Filters/QuestFilter.py
+++ b/PokeAlarm/Filters/QuestFilter.py
@@ -3,7 +3,8 @@ import operator
 # 3rd Party Imports
 # Local Imports
 from . import BaseFilter
-from PokeAlarm.Utilities import GymUtils as GymUtils
+from PokeAlarm.Utilities import GymUtils as GymUtils, QuestUtils
+
 
 class QuestFilter(BaseFilter):
     """ Filter class for limiting which quests trigger a notification. """
@@ -19,7 +20,7 @@ class QuestFilter(BaseFilter):
         self.max_dist = self.evaluate_attribute(  # f.max_dist <= m.distance
             event_attribute='distance', eval_func=operator.ge,
             limit=BaseFilter.parse_as_type(float, 'max_dist', data))
-            
+
         # Quest Description
         self.quest_contains = self.evaluate_attribute(  # f.gn matches e.gn
             event_attribute='quest', eval_func=GymUtils.match_regex_dict,
@@ -30,7 +31,7 @@ class QuestFilter(BaseFilter):
             eval_func=GymUtils.not_match_regex_dict,
             limit=BaseFilter.parse_as_set(
                 GymUtils.create_regex, 'quest_excludes', data))
-                
+
         # Reward Description
         self.reward_contains = self.evaluate_attribute(  # f.gn matches e.gn
             event_attribute='reward', eval_func=GymUtils.match_regex_dict,
@@ -41,6 +42,11 @@ class QuestFilter(BaseFilter):
             eval_func=GymUtils.not_match_regex_dict,
             limit=BaseFilter.parse_as_set(
                 GymUtils.create_regex, 'reward_excludes', data))
+
+        self.types = self.evaluate_attribute(
+            event_attribute='type', eval_func=operator.contains,
+            limit=BaseFilter.parse_as_set(QuestUtils.get_type, 'type', data)
+        )
 
         # Geofences
         self.geofences = BaseFilter.parse_as_list(str, 'geofences', data)

--- a/PokeAlarm/Filters/QuestFilter.py
+++ b/PokeAlarm/Filters/QuestFilter.py
@@ -25,7 +25,7 @@ class QuestFilter(BaseFilter):
             event_attribute='quest', eval_func=GymUtils.match_regex_dict,
             limit=BaseFilter.parse_as_set(
                 GymUtils.create_regex, 'quest_contains', data))
-        self.gym_name_excludes = self.evaluate_attribute(  # f.gn no-match e.gn
+        self.quest_excludes = self.evaluate_attribute(  # f.gn no-match e.gn
             event_attribute='quest',
             eval_func=GymUtils.not_match_regex_dict,
             limit=BaseFilter.parse_as_set(
@@ -36,7 +36,7 @@ class QuestFilter(BaseFilter):
             event_attribute='reward', eval_func=GymUtils.match_regex_dict,
             limit=BaseFilter.parse_as_set(
                 GymUtils.create_regex, 'reward_contains', data))
-        self.gym_name_excludes = self.evaluate_attribute(  # f.gn no-match e.gn
+        self.reward_excludes = self.evaluate_attribute(  # f.gn no-match e.gn
             event_attribute='reward',
             eval_func=GymUtils.not_match_regex_dict,
             limit=BaseFilter.parse_as_set(

--- a/PokeAlarm/Filters/QuestFilter.py
+++ b/PokeAlarm/Filters/QuestFilter.py
@@ -45,7 +45,7 @@ class QuestFilter(BaseFilter):
 
         self.types = self.evaluate_attribute(
             event_attribute='type', eval_func=operator.contains,
-            limit=BaseFilter.parse_as_set(QuestUtils.get_type, 'type', data)
+            limit=BaseFilter.parse_as_set(QuestUtils.get_type, 'types', data)
         )
 
         # Geofences
@@ -62,7 +62,7 @@ class QuestFilter(BaseFilter):
         # Reject leftover parameters
         for key in data:
             raise ValueError("'{}' is not a recognized parameter for"
-                             " Stop filters".format(key))
+                             " Quest filters".format(key))
 
     def to_dict(self):
         """ Create a dict representation of this Filter. """

--- a/PokeAlarm/Filters/QuestFilter.py
+++ b/PokeAlarm/Filters/QuestFilter.py
@@ -43,9 +43,10 @@ class QuestFilter(BaseFilter):
             limit=BaseFilter.parse_as_set(
                 GymUtils.create_regex, 'reward_excludes', data))
 
-        self.types = self.evaluate_attribute(
-            event_attribute='type', eval_func=operator.contains,
-            limit=BaseFilter.parse_as_set(QuestUtils.get_type, 'types', data)
+        self.reward_types = self.evaluate_attribute(
+            event_attribute='reward_type', eval_func=operator.contains,
+            limit=BaseFilter.parse_as_set(QuestUtils.get_reward_type,
+                                          'reward_types', data)
         )
 
         # Geofences

--- a/PokeAlarm/Filters/__init__.py
+++ b/PokeAlarm/Filters/__init__.py
@@ -5,3 +5,4 @@ from GymFilter import GymFilter  # noqa F401
 from EggFilter import EggFilter  # noqa F401
 from RaidFilter import RaidFilter  # noqa F401
 from WeatherFilter import WeatherFilter # noqa F401
+from QuestFilter import QuestFilter  # noqa F401

--- a/PokeAlarm/Load.py
+++ b/PokeAlarm/Load.py
@@ -189,8 +189,8 @@ def parse_rules_file(manager, filename):
         load_rules_section(manager.add_raid_rule, rules.pop('raids', {}))
         log.debug("Parsing 'weather' section.")
         load_rules_section(manager.add_weather_rule, rules.pop('weather', {}))
-        log.debug("Parsing 'quest' section.")
-        load_rules_section(manager.add_quest_rule, rules.pop('quest', {}))
+        log.debug("Parsing 'quests' section.")
+        load_rules_section(manager.add_quest_rule, rules.pop('quests', {}))
 
         for key in rules:
             raise ValueError("Unknown Event type '{}'. Rules must be defined "

--- a/PokeAlarm/Load.py
+++ b/PokeAlarm/Load.py
@@ -85,6 +85,13 @@ def parse_filters_file(mgr, filename):
         for name, f in filters.iteritems():
             mgr.add_weather_filter(name, f)
 
+        # Load Quest Section
+        section = filters_file.pop('quest', {'enabled': False})
+        mgr.set_quest_enabled(section.pop('enabled', True))
+        filters = parse_filter_section(section)
+        for name, f in filters.iteritems():
+            mgr.add_quest_filter(name, f)
+
         return  # exit function
 
     except Exception as e:
@@ -182,6 +189,8 @@ def parse_rules_file(manager, filename):
         load_rules_section(manager.add_raid_rule, rules.pop('raids', {}))
         log.debug("Parsing 'weather' section.")
         load_rules_section(manager.add_weather_rule, rules.pop('weather', {}))
+        log.debug("Parsing 'quest' section.")
+        load_rules_section(manager.add_quest_rule, rules.pop('quest', {}))
 
         for key in rules:
             raise ValueError("Unknown Event type '{}'. Rules must be defined "

--- a/PokeAlarm/Locale.py
+++ b/PokeAlarm/Locale.py
@@ -103,6 +103,12 @@ class Locale(object):
         for id_, val in default['day_or_night'].iteritems():
             self.__day_or_night_names[int(id_)] = day_or_night.get(id_, val)
 
+        # Quest Type ID -> Quest Type Name
+        self.__quest_type_names = {}
+        quest_types = info.get('quest_types', {})
+        for id_, val in default['quest_types'].iteritems():
+            self.__quest_type_names[int(id_)] = quest_types.get(id_, val)
+
         log.debug("Loaded '{}' locale successfully!".format(language))
 
         self.__misc = info.get('misc', {})
@@ -156,3 +162,6 @@ class Locale(object):
 
     def get_day_or_night(self, day_or_night_id):
         return self.__day_or_night_names.get(day_or_night_id, 'unknown')
+
+    def get_quest_type_name(self, quest_type_id):
+        return self.__quest_type_names.get(quest_type_id, 'unknown')

--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -999,11 +999,22 @@ class Manager(object):
             quest.direction = get_cardinal_dir(
                 [quest.lat, quest.lng], self.__location)
 
-        # Store copy of cache info
-        # TODO
+        # Skip if previously processed
+        if self.__cache.quest_expiration(quest.stop_id) is not None:
+            self._log.debug("Quest {} was skipped because it was "
+                            "previously processed.".format(quest.name))
+            return
+        self.__cache.quest_expiration(quest.stop_id, quest.expire_time)
+
+        # Check against previous copy from cache
+        previous_reward, previous_task = \
+            self.__cache.quest_reward(quest.stop_id)
+        if quest.reward == previous_reward and quest.quest == previous_task:
+            self._log.debug("Quest ignored: Reward previously alerted!")
+            return
 
         # Update cache info
-        # TODO
+        self.__cache.quest_reward(quest.stop_id, quest.reward, quest.quest)
 
         # Check for Rules
         rules = self.__quest_rules

--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -73,6 +73,7 @@ class Manager(object):
         self._eggs_enabled, self._egg_filters = False, OrderedDict()
         self._raids_enabled, self._raid_filters = False, OrderedDict()
         self._weather_enabled, self._weather_filters = False, OrderedDict()
+        self._quest_enabled, self._quest_filters = False, OrderedDict()
 
         # Create the Geofences to filter with from given file
         self.geofences = None
@@ -89,6 +90,7 @@ class Manager(object):
         self.__egg_rules = {}
         self.__raid_rules = {}
         self.__weather_rules = {}
+        self.__quest_rules = {}
 
         # Initialize the queue and start the process
         self.__queue = Queue()
@@ -305,6 +307,21 @@ class Manager(object):
         self._weather_filters[name] = f
         self._log.debug("Weather filter '%s' set: %s", name, f)
 
+    # Enable/Disable Quest notifications
+    def set_quest_enabled(self, boolean):
+        self._quest_enabled = parse_bool(boolean)
+        self._log.debug("Quest notifications %s!",
+                        "enabled" if self._quest_enabled else "disabled")
+
+    # Add new Weather Filter
+    def add_quest_filter(self, name, settings):
+        if name in self._quest_filters:
+            raise ValueError("Unable to add Quest Filter: Filter with the "
+                             "name {} already exists!".format(name))
+        f = Filters.QuestFilter(self, name, settings)
+        self._quest_filters[name] = f
+        self._log.debug("Quest filter '%s' set: %s", name, f)
+
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ALARMS API ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -429,6 +446,20 @@ class Manager(object):
 
         self.__weather_rules[name] = Rule(filters, alarms)
 
+    def add_quest_rule(self, name, filters, alarms):
+        if name in self.__quest_rules:
+            raise ValueError("Unable to add Rule: Quest Rule with the name "
+                             "{} already exists!".format(name))
+        for filt in filters:
+            if filt not in self._quest_filters:
+                raise ValueError("Unable to create Rule: No quest Filter "
+                                 "named {}!".format(filt))
+        for alarm in alarms:
+            if alarm not in self._alarms:
+                raise ValueError("Unable to create Rule: No Alarm "
+                                 "named {}!".format(alarm))
+        self.__quest_rules[name] = Rule(filters, alarms)
+
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MANAGER LOADING ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -497,6 +528,8 @@ class Manager(object):
                     self.process_raid(event)
                 elif kind == Events.WeatherEvent:
                     self.process_weather(event)
+                elif kind == Events.QuestEvent:
+                    self.process_quest(event)
                 else:
                     self._log.error(
                         "!!! Manager does not support {} events!".format(kind))
@@ -945,6 +978,56 @@ class Manager(object):
         else:
             self._rule_log.info(
                 'Weather %s rejected by all rules.', weather.name)
+
+    def process_quest(self, quest):
+        # type: (Events.QuestEvent) -> None
+        """ Process a quest event and notify alarms if it passes. """
+
+        # Set the name for this event so we can log rejects better
+        quest.name = quest.stop_name + '-' + quest.reward
+
+        # Make sure that quest changes are enabled
+        if self._quest_enabled is False:
+            self._log.debug("Quest ignored: quest "
+                            "notifications are disabled.")
+            return
+
+        # Calculate distance and direction
+        if self.__location is not None:
+            quest.distance = get_earth_dist(
+                [quest.lat, quest.lng], self.__location, self.__units)
+            quest.direction = get_cardinal_dir(
+                [quest.lat, quest.lng], self.__location)
+
+        # Store copy of cache info
+        # TODO
+
+        # Update cache info
+        # TODO
+
+        # Check for Rules
+        rules = self.__quest_rules
+        if len(rules) == 0:  # If no rules, default to all
+            rules = {"default": Rule(
+                self._quest_filters.keys(), self._alarms.keys())}
+
+        rule_ct, alarm_ct = 0, 0
+        for r_name, rule in rules.iteritems():  # For all rules
+            passed = self._check_filters(
+                quest, self._quest_filters, rule.filter_names)
+            if passed:
+                rule_ct += 1
+                alarm_ct += len(rule.alarm_names)
+                self._notify_alarms(
+                    quest, rule.alarm_names, 'quest_alert')
+
+        if rule_ct > 0:
+            self._rule_log.info(
+                'Quest %s passed %s rule(s) and triggered %s alarm(s).',
+                quest.name, rule_ct, alarm_ct)
+        else:
+            self._rule_log.info(
+                'Quest %s rejected by all rules.', quest.name)
 
     # Check to see if a notification is within the given range
     # TODO: Move this into filters and add unit tests

--- a/PokeAlarm/Utilities/QuestUtils.py
+++ b/PokeAlarm/Utilities/QuestUtils.py
@@ -7,11 +7,11 @@ from PokeAlarm.Utils import get_path
 
 
 # Returns type of quest reward (e.g. monster, dust, etc.)
-def get_type(reward_type):
+def get_reward_type(reward_type):
     try:
         name = str(reward_type).lower()
-        if not hasattr(get_type, 'ids'):
-            get_type.ids = {}
+        if not hasattr(get_reward_type, 'ids'):
+            get_reward_type.ids = {}
             files = glob(get_path('locales/*.json'))
             for file_ in files:
                 with open(file_, 'r') as f:
@@ -19,29 +19,11 @@ def get_type(reward_type):
                     j = j['quest_types']
                     for id_ in j:
                         nm = j[id_].lower()
-                        get_type.ids[nm] = int(id_)
-        if name in get_type.ids:
-            return get_type.ids[name]
+                        get_reward_type.ids[nm] = int(id_)
+        if name in get_reward_type.ids:
+            return get_reward_type.ids[name]
         else:
             return int(name)  # try as an integer
     except ValueError:
         raise ValueError("Unable to interpret `{}` as a valid "
-                         " severity name or id.".format(reward_type))
-    # if isinstance(type_id, int):
-    #     try:
-    #         if not hasattr(get_type, 'types'):
-    #             get_type.types = {}
-    #             files = glob(get_path('locales/*.json'))
-    #             for file_ in files:
-    #                 with open(file_, 'r') as f:
-    #                     j = json.loads(f.read())
-    #                     j = j['quest_types']
-    #                     for id_ in j:
-    #                         get_type.types[id_] = j[id_]
-    #         if type_id in get_type.types:
-    #             return get_type.types[type_id]
-    #         else:
-    #             return type_id
-    #     except ValueError:
-    #         raise ValueError("Unable to interpret `{}` as a valid type id"
-    #                          .format(type_id))
+                         " quest reward type or id.".format(reward_type))

--- a/PokeAlarm/Utilities/QuestUtils.py
+++ b/PokeAlarm/Utilities/QuestUtils.py
@@ -1,0 +1,27 @@
+# Standard Library Imports
+from glob import glob
+import json
+# 3rd Party Imports
+# Local Imports
+from PokeAlarm.Utils import get_path
+
+
+# Returns type of quest reward (e.g. monster, dust, etc.)
+def get_type(type_id):
+    if isinstance(type_id, int):
+        try:
+            if not hasattr(get_type, 'types'):
+                files = glob(get_path('locales/*.json'))
+                for file_ in files:
+                    with open(file_, 'r') as f:
+                        j = json.loads(f.read())
+                        j = j['quest_types']
+                        for id_ in j:
+                            get_type.types[id_] = j[id_].lower()
+            if type_id in get_type.types:
+                return get_type.types[type_id]
+            else:
+                return type_id
+        except ValueError:
+            raise ValueError("Unable to interpret `{}` as a valid type id"
+                             .format(type_id))

--- a/PokeAlarm/Utilities/QuestUtils.py
+++ b/PokeAlarm/Utilities/QuestUtils.py
@@ -7,21 +7,41 @@ from PokeAlarm.Utils import get_path
 
 
 # Returns type of quest reward (e.g. monster, dust, etc.)
-def get_type(type_id):
-    if isinstance(type_id, int):
-        try:
-            if not hasattr(get_type, 'types'):
-                files = glob(get_path('locales/*.json'))
-                for file_ in files:
-                    with open(file_, 'r') as f:
-                        j = json.loads(f.read())
-                        j = j['quest_types']
-                        for id_ in j:
-                            get_type.types[id_] = j[id_].lower()
-            if type_id in get_type.types:
-                return get_type.types[type_id]
-            else:
-                return type_id
-        except ValueError:
-            raise ValueError("Unable to interpret `{}` as a valid type id"
-                             .format(type_id))
+def get_type(reward_type):
+    try:
+        name = str(reward_type).lower()
+        if not hasattr(get_type, 'ids'):
+            get_type.ids = {}
+            files = glob(get_path('locales/*.json'))
+            for file_ in files:
+                with open(file_, 'r') as f:
+                    j = json.loads(f.read())
+                    j = j['quest_types']
+                    for id_ in j:
+                        nm = j[id_].lower()
+                        get_type.ids[nm] = int(id_)
+        if name in get_type.ids:
+            return get_type.ids[name]
+        else:
+            return int(name)  # try as an integer
+    except ValueError:
+        raise ValueError("Unable to interpret `{}` as a valid "
+                         " severity name or id.".format(reward_type))
+    # if isinstance(type_id, int):
+    #     try:
+    #         if not hasattr(get_type, 'types'):
+    #             get_type.types = {}
+    #             files = glob(get_path('locales/*.json'))
+    #             for file_ in files:
+    #                 with open(file_, 'r') as f:
+    #                     j = json.loads(f.read())
+    #                     j = j['quest_types']
+    #                     for id_ in j:
+    #                         get_type.types[id_] = j[id_]
+    #         if type_id in get_type.types:
+    #             return get_type.types[type_id]
+    #         else:
+    #             return type_id
+    #     except ValueError:
+    #         raise ValueError("Unable to interpret `{}` as a valid type id"
+    #                          .format(type_id))

--- a/locales/de.json
+++ b/locales/de.json
@@ -948,6 +948,16 @@
     "720": "Hoopa", 
     "721": "Volcanion"
   },
+  "quest_types": {
+    "000": "Unset",
+    "001": "Experience",
+    "002": "Item",
+    "003": "Stardust",
+    "004": "Candy",
+    "005": "Avatar Clothing",
+    "006": "Quest",
+    "007": "Monster Encounter"
+  },
   "rarity": {
     "000": "Neuer Spawn",
     "001": "Häufig",

--- a/locales/de.json
+++ b/locales/de.json
@@ -949,14 +949,14 @@
     "721": "Volcanion"
   },
   "quest_types": {
-    "000": "Unset",
-    "001": "Experience",
-    "002": "Item",
-    "003": "Stardust",
-    "004": "Candy",
-    "005": "Avatar Clothing",
-    "006": "Quest",
-    "007": "Monster Encounter"
+    "000": "Nicht festgelegt",
+    "001": "Erfahrung",
+    "002": "Artikel",
+    "003": "Sternenstaub",
+    "004": "S\u00FC\u00DFigkeiten",
+    "005": "Avatar Kleidung",
+    "006": "Suche",
+    "007": "Monsterbegegnung"
   },
   "rarity": {
     "000": "Neuer Spawn",

--- a/locales/en.json
+++ b/locales/en.json
@@ -992,6 +992,16 @@
     "720": "Hoopa", 
     "721": "Volcanion"
   },
+  "quest_types": {
+    "000": "Unset",
+    "001": "Experience",
+    "002": "Item",
+    "003": "Stardust",
+    "004": "Candy",
+    "005": "Avatar Clothing",
+    "006": "Quest",
+    "007": "Monster Encounter"
+  },
   "rarity": {
     "000": "New Spawn",
     "001": "Common",

--- a/locales/es.json
+++ b/locales/es.json
@@ -945,14 +945,14 @@
     "721": "Volcanion"
   },
   "quest_types": {
-    "000": "Unset",
-    "001": "Experience",
-    "002": "Item",
+    "000": "Desarmado",
+    "001": "Experiencia",
+    "002": "\u00EDt.",
     "003": "Stardust",
-    "004": "Candy",
-    "005": "Avatar Clothing",
-    "006": "Quest",
-    "007": "Monster Encounter"
+    "004": "Caramelo",
+    "005": "Ropa de avatar",
+    "006": "B\u00FAsqueda",
+    "007": "Encuentro de monstruos"
   },
   "rarity": {
     "000": "Nuevo engendro",

--- a/locales/es.json
+++ b/locales/es.json
@@ -944,6 +944,16 @@
     "720": "Hoopa", 
     "721": "Volcanion"
   },
+  "quest_types": {
+    "000": "Unset",
+    "001": "Experience",
+    "002": "Item",
+    "003": "Stardust",
+    "004": "Candy",
+    "005": "Avatar Clothing",
+    "006": "Quest",
+    "007": "Monster Encounter"
+  },
   "rarity": {
     "000": "Nuevo engendro",
     "001": "Común",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -945,14 +945,14 @@
     "721": "Volcanion"
   },
   "quest_types": {
-    "000": "Unset",
-    "001": "Experience",
-    "002": "Item",
-    "003": "Stardust",
-    "004": "Candy",
-    "005": "Avatar Clothing",
-    "006": "Quest",
-    "007": "Monster Encounter"
+    "000": "Non d\u00E9fini",
+    "001": "Exp\u00E9rience",
+    "002": "Article",
+    "003": "poussi\u00E8re d'\u00E9toiles",
+    "004": "Bonbons",
+    "005": "V\u00EAtements Avatar",
+    "006": "Qu\u00EAte",
+    "007": "Rencontre de monstres"
   },
   "rarity": {
     "000": "Nouveau Spawn",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -944,6 +944,16 @@
     "720": "Hoopa", 
     "721": "Volcanion"
   },
+  "quest_types": {
+    "000": "Unset",
+    "001": "Experience",
+    "002": "Item",
+    "003": "Stardust",
+    "004": "Candy",
+    "005": "Avatar Clothing",
+    "006": "Quest",
+    "007": "Monster Encounter"
+  },
   "rarity": {
     "000": "Nouveau Spawn",
     "001": "Commun",

--- a/locales/it.json
+++ b/locales/it.json
@@ -948,6 +948,16 @@
     "720": "Hoopa", 
     "721": "Volcanion"
   },
+  "quest_types": {
+    "000": "Unset",
+    "001": "Experience",
+    "002": "Item",
+    "003": "Stardust",
+    "004": "Candy",
+    "005": "Avatar Clothing",
+    "006": "Quest",
+    "007": "Monster Encounter"
+  },
   "rarity": {
     "000": "Nuevo engendro",
     "001": "Comune",

--- a/locales/it.json
+++ b/locales/it.json
@@ -949,14 +949,14 @@
     "721": "Volcanion"
   },
   "quest_types": {
-    "000": "Unset",
-    "001": "Experience",
-    "002": "Item",
-    "003": "Stardust",
-    "004": "Candy",
-    "005": "Avatar Clothing",
-    "006": "Quest",
-    "007": "Monster Encounter"
+    "000": "unset",
+    "001": "Esperienza",
+    "002": "Articolo",
+    "003": "polvere di stelle",
+    "004": "caramella",
+    "005": "Abbigliamento Avatar",
+    "006": "Ricerca",
+    "007": "Incontro dei mostri"
   },
   "rarity": {
     "000": "Nuevo engendro",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -896,14 +896,14 @@
     "721": "\ubcfc\ucf00\ub2c8\uc628"
   },
   "quest_types": {
-    "000": "Unset",
-    "001": "Experience",
-    "002": "Item",
-    "003": "Stardust",
-    "004": "Candy",
-    "005": "Avatar Clothing",
-    "006": "Quest",
-    "007": "Monster Encounter"
+    "000": "\uC124\uC815 \uD574\uC81C",
+    "001": "\uACBD\uD5D8",
+    "002": "\uBAA9",
+    "003": "\uC2A4\uD0C0 \uB354\uC2A4\uD2B8",
+    "004": "\uC0AC\uD0D5",
+    "005": "\uC544\uBC14\uD0C0 \uC758\uB958",
+    "006": "\uD0D0\uAD6C",
+    "007": "\uBAAC\uC2A4\uD130 \uB9CC\uB0A8"
   },
   "rarity": {
     "000": "\uc0c8\ub85c\uc6b4 \uc2a4\ud3f0",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -895,6 +895,16 @@
     "720": "\ud6c4\ud30c", 
     "721": "\ubcfc\ucf00\ub2c8\uc628"
   },
+  "quest_types": {
+    "000": "Unset",
+    "001": "Experience",
+    "002": "Item",
+    "003": "Stardust",
+    "004": "Candy",
+    "005": "Avatar Clothing",
+    "006": "Quest",
+    "007": "Monster Encounter"
+  },
   "rarity": {
     "000": "\uc0c8\ub85c\uc6b4 \uc2a4\ud3f0",
     "001": "\uacf5\uc720\uc9c0",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -981,6 +981,16 @@
     "720": "Hoopa", 
     "721": "Volcanion"
   },
+  "quest_types": {
+    "000": "Unset",
+    "001": "Experience",
+    "002": "Item",
+    "003": "Stardust",
+    "004": "Candy",
+    "005": "Avatar Clothing",
+    "006": "Quest",
+    "007": "Monster Encounter"
+  },
   "rarity": {
     "000": "Novo spawn", 
     "001": "Comum", 

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -982,14 +982,14 @@
     "721": "Volcanion"
   },
   "quest_types": {
-    "000": "Unset",
-    "001": "Experience",
+    "000": "Desviar",
+    "001": "Experi\u00EAncia",
     "002": "Item",
-    "003": "Stardust",
-    "004": "Candy",
-    "005": "Avatar Clothing",
-    "006": "Quest",
-    "007": "Monster Encounter"
+    "003": "poeira estelar",
+    "004": "Doces",
+    "005": "Vestu\u00E1rio Avatar",
+    "006": "Busca",
+    "007": "Encontro Monstro"
   },
   "rarity": {
     "000": "Novo spawn", 

--- a/locales/zh_hk.json
+++ b/locales/zh_hk.json
@@ -948,6 +948,16 @@
     "720": "\u80e1\u5e15", 
     "721": "\u6ce2\u723e\u51f1\u5c3c\u6069"
   },
+  "quest_types": {
+    "000": "Unset",
+    "001": "Experience",
+    "002": "Item",
+    "003": "Stardust",
+    "004": "Candy",
+    "005": "Avatar Clothing",
+    "006": "Quest",
+    "007": "Monster Encounter"
+  },
   "rarity": {
     "000": "\u65b0\u7684\u7522\u5375",
     "001": "\u5171\u540c",

--- a/locales/zh_hk.json
+++ b/locales/zh_hk.json
@@ -949,14 +949,14 @@
     "721": "\u6ce2\u723e\u51f1\u5c3c\u6069"
   },
   "quest_types": {
-    "000": "Unset",
-    "001": "Experience",
-    "002": "Item",
-    "003": "Stardust",
-    "004": "Candy",
-    "005": "Avatar Clothing",
-    "006": "Quest",
-    "007": "Monster Encounter"
+    "000": "\u53D6\u6D88\u8BBE\u7F6E",
+    "001": "\u7ECF\u9A8C",
+    "002": "\u9879\u76EE",
+    "003": "\u661F\u5C18",
+    "004": "\u7CD6\u679C",
+    "005": "\u963F\u51E1\u8FBE\u670D\u88C5",
+    "006": "\u5BFB\u6C42",
+    "007": "\u602A\u7269\u906D\u9047"
   },
   "rarity": {
     "000": "\u65b0\u7684\u7522\u5375",

--- a/prototype/events/__init__.py
+++ b/prototype/events/__init__.py
@@ -18,5 +18,6 @@ from .gym import Gym
 from .egg import Egg
 from .raid import Raid
 from .weather import Weather
+from .quest import Quest
 
-TYPES = [Monster, Stop, Gym, Egg, Raid, Weather]
+TYPES = [Monster, Stop, Gym, Egg, Raid, Weather, Quest]

--- a/prototype/events/quest.py
+++ b/prototype/events/quest.py
@@ -8,6 +8,7 @@ This module contains classes for managing changes to quests.
 """
 
 # Standard Library Imports
+from datetime import datetime, date, time
 # 3rd Party Imports
 # Local Imports
 from _base import Event, EventAttr
@@ -28,13 +29,16 @@ class Quest(Event):
 
     # Identification
     stop_id = EventAttr(['pokestop_id'], str, required=True)  # type: str
-    type = EventAttr(['type'], int, default=0)  # type: int
+    reward_type = EventAttr(['type'], int, default=0)  # type: int
 
     # Details
     quest = EventAttr(['quest'], str, required=True)  # type: str
     reward = EventAttr(['reward'], str, required=True)  # type: str
+    expire_time = EventAttr(
+        ['expire_time'], datetime.utcfromtimestamp,
+        default=(datetime.combine(date.today(), time(23, 59))
+                 - datetime(1970, 1, 1)).total_seconds())
+    # type: float
 
-    expire_time = EventAttr(['expire_time'], str)
-
-    stop_image = EventAttr(['stop_image'], str)
-    stop_name = EventAttr(['stop_name'], str)
+    stop_image = EventAttr(['pokestop_url', 'url'], str)  # type: str
+    stop_name = EventAttr(['pokestop_name', 'name'], str)  # type: str

--- a/prototype/events/quest.py
+++ b/prototype/events/quest.py
@@ -8,7 +8,6 @@ This module contains classes for managing changes to quests.
 """
 
 # Standard Library Imports
-from datetime import datetime
 # 3rd Party Imports
 # Local Imports
 from _base import Event, EventAttr
@@ -22,6 +21,7 @@ class Quest(Event):
     # Location
     lat = EventAttr(['latitude'], float)  # type: float
     lng = EventAttr(['longitude'], float)  # type: float
+    # TODO: distance and direction by manager
     # Completed by Manager
     distance = None  # type: float
     direction = None  # type: str
@@ -34,10 +34,7 @@ class Quest(Event):
     quest = EventAttr(['quest'], str, required=True)  # type: str
     reward = EventAttr(['reward'], str, required=True)  # type: str
 
-    @property
-    def expiry(self):
-        # type: () -> str
-        return datetime.now().strftime("%d/%m/%Y 23:59")
+    expire_time = EventAttr(['expire_time'], str)
 
     stop_image = EventAttr(['stop_image'], str)
     stop_name = EventAttr(['stop_name'], str)

--- a/prototype/events/quest.py
+++ b/prototype/events/quest.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+"""
+pokealarm.events.quest
+~~~~~~~~~~~~~~~~
+
+This module contains classes for managing changes to quests.
+"""
+
+# Standard Library Imports
+from datetime import datetime
+# 3rd Party Imports
+# Local Imports
+from _base import Event, EventAttr
+
+
+class Quest(Event):
+    """
+    Object representation of a change to a quest.
+    """
+
+    # Location
+    lat = EventAttr(['latitude'], float)  # type: float
+    lng = EventAttr(['longitude'], float)  # type: float
+    # Completed by Manager
+    distance = None  # type: float
+    direction = None  # type: str
+
+    # Identification
+    stop_id = EventAttr(['pokestop_id'], str, required=True)  # type: str
+    type = EventAttr(['type'], int, default=0)  # type: int
+
+    # Details
+    quest = EventAttr(['quest'], str, required=True)  # type: str
+    reward = EventAttr(['reward'], str, required=True)  # type: str
+
+    @property
+    def expiry(self):
+        # type: () -> str
+        return datetime.now().strftime("%d/%m/%Y 23:59")
+
+    stop_image = EventAttr(['stop_image'], str)
+    stop_name = EventAttr(['stop_name'], str)

--- a/start_pokealarm.py
+++ b/start_pokealarm.py
@@ -14,7 +14,7 @@ import os
 import sys
 # 3rd Party Imports
 import configargparse
-from gevent import wsgi, spawn, signal, pool, queue
+from gevent import pywsgi, spawn, signal, pool, queue
 from flask import Flask, request, abort
 import pytz
 # Local Imports
@@ -101,7 +101,7 @@ def start_server():
              "".format(config['HOST'], config['PORT']))
     threads = pool.Pool(config['CONCURRENCY'])
     global server
-    server = wsgi.WSGIServer(
+    server = pywsgi.WSGIServer(
         (config['HOST'], config['PORT']), app,
         log=logging.getLogger('webserver.internal'),
         spawn=threads)

--- a/tests/events/test_quest.py
+++ b/tests/events/test_quest.py
@@ -2,6 +2,7 @@
 
 # Standard Library Imports
 import unittest
+import datetime
 # 3rd Party Imports
 # Local Imports
 from prototype.events import Quest
@@ -60,11 +61,12 @@ class TestStopEvent(unittest.TestCase):
         self.assertTrue(isinstance(quest.reward, str))
         self.assertTrue(quest.reward == 'Get Stuff')
 
-    def test_expiry(self):
-        quest = generic_quest({})
-        self.assertTrue(isinstance(quest.expiry, str))
+    def test_expire_time(self):
+        quest = generic_quest({'expire_time': datetime.
+                              datetime.now().strftime("%d/%m/%Y 23:59")})
+        self.assertTrue(isinstance(quest.expire_time, str))
 
     def test_type(self):
         quest = generic_quest({'type': 7})
-        self.assertTrue(isinstance(quest.type_id, int))
-        self.assertTrue(quest.type_id == 7)
+        self.assertTrue(isinstance(quest.reward_type_id, int))
+        self.assertTrue(quest.reward_type_id == 7)

--- a/tests/events/test_quest.py
+++ b/tests/events/test_quest.py
@@ -2,7 +2,7 @@
 
 # Standard Library Imports
 import unittest
-import datetime
+from datetime import datetime, time, date
 # 3rd Party Imports
 # Local Imports
 from prototype.events import Quest
@@ -62,11 +62,23 @@ class TestStopEvent(unittest.TestCase):
         self.assertTrue(quest.reward == 'Get Stuff')
 
     def test_expire_time(self):
-        quest = generic_quest({'expire_time': datetime.
-                              datetime.now().strftime("%d/%m/%Y 23:59")})
-        self.assertTrue(isinstance(quest.expire_time, str))
+        # Check if it defaults to today at 23:59
+        quest = generic_quest([])
+        midnight_tonight = datetime.utcfromtimestamp(
+            (datetime.combine(date.today(), time(23, 59))
+             - datetime(1970, 1, 1)).total_seconds())
+        self.assertTrue(isinstance(quest.expire_time, datetime))
+        self.assertTrue(quest.expire_time == midnight_tonight)
+
+        # Check if it accepts the webhook field
+        midnight_tonight = (datetime.combine(date.today(), time(23, 30))
+                            - datetime(1970, 1, 1)).total_seconds()
+        quest = generic_quest({'expire_time': midnight_tonight})
+        self.assertTrue(isinstance(quest.expire_time, datetime))
+        self.assertTrue(quest.expire_time ==
+                        datetime.utcfromtimestamp(midnight_tonight))
 
     def test_type(self):
         quest = generic_quest({'type': 7})
-        self.assertTrue(isinstance(quest.reward_type_id, int))
-        self.assertTrue(quest.reward_type_id == 7)
+        self.assertTrue(isinstance(quest.reward_type, int))
+        self.assertTrue(quest.reward_type == 7)

--- a/tests/events/test_quest.py
+++ b/tests/events/test_quest.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+
+# Standard Library Imports
+import unittest
+# 3rd Party Imports
+# Local Imports
+from prototype.events import Quest
+
+
+def generic_quest(values):
+    """ Generate a generic quest, overriding with an specific values. """
+    settings = {
+        "pokestop_id": 0,
+        "pokestop_name": "Stop Name",
+        "pokestop_url": "http://placehold.it/500x500",
+        "latitude": 37.7876146,
+        "longitude": -122.390624,
+        "quest": "Do Stuff",
+        "reward": "Get Stuff",
+        "type": 0
+    }
+    settings.update(values)
+    return Quest(settings)
+
+
+class TestStopEvent(unittest.TestCase):
+
+    def test_lat(self):
+        quest = generic_quest({'latitude': 0})
+        self.assertTrue(isinstance(quest.lat, float))
+        self.assertTrue(quest.lat == 0.0)
+
+    def test_lng(self):
+        quest = generic_quest({'longitude': 0})
+        self.assertTrue(isinstance(quest.lng, float))
+        self.assertTrue(quest.lng == 0.0)
+
+    def test_stop_id(self):
+        quest = generic_quest({'pokestop_id': 1})
+        self.assertTrue(isinstance(quest.stop_id, str))
+        self.assertTrue(quest.stop_id == "1")
+
+    def test_stop_name(self):
+        quest = generic_quest({'pokestop_name': 'Stop Name'})
+        self.assertTrue(isinstance(quest.stop_name, str))
+        self.assertTrue(quest.stop_name == "Stop Name")
+
+    def test_stop_url(self):
+        quest = generic_quest({'pokestop_url': 'http://placehold.it/1x1'})
+        self.assertTrue(isinstance(quest.stop_image, str))
+        self.assertTrue(quest.stop_image == "http://placehold.it/1x1")
+
+    def test_quest(self):
+        quest = generic_quest({'quest': 'Do Stuff'})
+        self.assertTrue(isinstance(quest.quest, str))
+        self.assertTrue(quest.quest == 'Do Stuff')
+
+    def test_reward(self):
+        quest = generic_quest({'reward': 'Get Stuff'})
+        self.assertTrue(isinstance(quest.reward, str))
+        self.assertTrue(quest.reward == 'Get Stuff')
+
+    def test_expiry(self):
+        quest = generic_quest({})
+        self.assertTrue(isinstance(quest.expiry, str))
+
+    def test_type(self):
+        quest = generic_quest({'type': 7})
+        self.assertTrue(isinstance(quest.type_id, int))
+        self.assertTrue(quest.type_id == 7)

--- a/tests/filters/test_quest_filter.py
+++ b/tests/filters/test_quest_filter.py
@@ -1,0 +1,108 @@
+import unittest
+import PokeAlarm.Filters as Filters
+import PokeAlarm.Events as Events
+from tests.filters import MockManager, generic_filter_test
+
+
+class TestQuestFilter(unittest.TestCase):
+
+    @classmethod
+    def setUp(cls):
+        cls._mgr = MockManager()
+
+    @classmethod
+    def tearDown(cls):
+        pass
+
+    def gen_filter(self, settings):
+        """ Generate a generic filter with given settings. """
+        return Filters.QuestFilter(self._mgr, "testfilter", settings)
+
+    def gen_event(self, values):
+        """ Generate a generic quest, overriding with an specific values. """
+        settings = {
+            "pokestop_id": 0,
+            "pokestop_name": "Stop Name",
+            "pokestop_url": "http://placehold.it/500x500",
+            "latitude": 37.7876146,
+            "longitude": -122.390624,
+            "quest": "Do Stuff",
+            "reward": "Get Stuff",
+            "type": 0
+        }
+        settings.update(values)
+        return Events.QuestEvent(settings)
+
+    def test_distance(self):
+        # Create the filter
+        filt = self.gen_filter(
+            {"max_dist": 2000, "min_dist": 400})
+
+        # Test passing
+        quest = self.gen_event({})
+        for dist in [1000, 800, 600]:
+            quest.distance = dist
+            self.assertTrue(filt.check_event(quest))
+
+        # Test failing
+        quest = self.gen_event({})
+        for dist in [0, 300, 3000]:
+            quest.distance = dist
+            self.assertFalse(filt.check_event(quest))
+
+    def test_missing_info(self):
+        # Create the filters
+        missing = self.gen_filter(
+            {"max_dist": "inf", "is_missing_info": True})
+        not_missing = self.gen_filter(
+            {"max_dist": "inf", "is_missing_info": False})
+
+        # Test missing
+        miss_event = self.gen_event({})
+        self.assertTrue(missing.check_event(miss_event))
+        self.assertFalse(not_missing.check_event(miss_event))
+
+        # Test not missing
+        info_event = self.gen_event({})
+        info_event.distance = 1000
+        self.assertTrue(not_missing.check_event(info_event))
+        self.assertFalse(missing.check_event(info_event))
+
+    @generic_filter_test
+    def test_quest_contains(self):
+        self.filt = {"quest_contains": ["stuff", "other", "uhh"]}
+        self.event_key = "quest"
+        self.pass_vals = ["do stuff", "do other things", "uhh stewart"]
+        self.fail_vals = ["you know", "I guess", "something"]
+
+    @generic_filter_test
+    def test_quest_excludes(self):
+        self.filt = {'quest_excludes': ['stuff', 'other', 'uhh']}
+        self.event_key = 'quest'
+        self.pass_vals = ['something', 'else', 'here']
+        self.fail_vals = ['some stuff', 'some other', 'uhh stewart']
+
+    @generic_filter_test
+    def test_reward_contains(self):
+        self.filt = {'reward_contains': ['stuff', 'other', 'uhh']}
+        self.event_key = 'reward'
+        self.pass_vals = ['some stuff', 'some other stuff', 'uhh stewart']
+        self.fail_vals = ['you know', 'this should', 'fail']
+
+    @generic_filter_test
+    def test_reward_excludes(self):
+        self.filt = {'reward_excludes': ['stuff', 'other', 'uhh']}
+        self.event_key = 'reward'
+        self.pass_vals = ['this', 'doesn\'t', 'contain']
+        self.fail_vals = ['some stuff', 'some other s', 'uhh stewart']
+
+    @generic_filter_test
+    def test_types(self):
+        self.filt = {'types': ['Monster Encounter', 1, 2]}
+        self.event_key = 'type'
+        self.pass_vals = [1, 2, 7]
+        self.fail_vals = [0, 3, 4]
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/filters/test_quest_filter.py
+++ b/tests/filters/test_quest_filter.py
@@ -98,7 +98,7 @@ class TestQuestFilter(unittest.TestCase):
 
     @generic_filter_test
     def test_types(self):
-        self.filt = {'types': ['Monster Encounter', 1, 2]}
+        self.filt = {'reward_types': ['Monster Encounter', '1', 2]}
         self.event_key = 'type'
         self.pass_vals = [1, 2, 7]
         self.fail_vals = [0, 3, 4]

--- a/tools/webhook_test.py
+++ b/tools/webhook_test.py
@@ -288,7 +288,7 @@ def list_stops():
                 i += 1
                 f.write("[{}] {} : {} \n".format(i, name, key))
             f.close()
-        print "Find list of stops in your \\tools\ folder (stops.txt)"
+        print "Find list of stops in your tools folder (stops.txt)"
         print "Enter stop id for raid (from file)\n>",
     else:
         print "Here is a list of stops found in your cache:"

--- a/tools/webhook_test.py
+++ b/tools/webhook_test.py
@@ -55,8 +55,6 @@ _cache = {}
 
 _gym_info = {}
 
-_stop_info = {}
-
 
 def set_init(webhook_type):
     payloadr = {}
@@ -193,11 +191,6 @@ def get_gym_info(gym_id):
     return _gym_info.get(gym_id, 'unknown')
 
 
-def get_stop_info(stop_id):
-    """ Gets the information about the stop. """
-    return _stop_info.get(stop_id, 'unknown')
-
-
 def gym_or_invalid(prm, prm2):
     questionable_input = raw_input()
     while get_gym_info(questionable_input) == "unknown":
@@ -206,16 +199,6 @@ def gym_or_invalid(prm, prm2):
     print "Gym found! {}".format(get_gym_info(questionable_input))
     payload["message"][prm] = questionable_input
     payload["message"][prm2] = get_gym_info(questionable_input)
-
-
-def stop_or_invalid(prm, prm2):
-    questionable_input = raw_input()
-    while get_stop_info(questionable_input) == "unknown":
-        print "Not a valid stop. Please try again..\n>",
-        questionable_input = raw_input()
-    print "Stop found! {}".format(get_stop_info(questionable_input))
-    payload["message"][prm] = questionable_input
-    payload["message"][prm2] = get_stop_info(questionable_input)
 
 
 def cache_or_invalid():
@@ -240,13 +223,6 @@ def load_gym_cache(file):
         _gym_info = data.get('gym_name', {})
 
 
-def load_stop_cache(file):
-    global _stop_info
-    with portalocker.Lock(file, mode="rb") as f:
-        data = pickle.load(f)
-        _stop_info = data.get('pokestop_name', {})
-
-
 def list_cache():
     path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     if not os.path.exists(os.path.join(path, "cache")):
@@ -256,6 +232,7 @@ def list_cache():
     for file in os.listdir(os.path.join(path, "cache")):
         if file.endswith(".cache"):
             print file
+    return True
 
 
 def list_gyms():
@@ -278,27 +255,6 @@ def list_gyms():
         print "Enter gym id for raid (from above)\n>",
 
 
-def list_stops():
-    path = os.path.dirname(os.path.abspath(__file__))
-    if len(_stop_info) > 50:
-        with portalocker.Lock(os.path.join(path, "stops.txt"), mode="wb+") \
-                as f:
-            i = 0
-            for key, name in _gym_info.items():
-                i += 1
-                f.write("[{}] {} : {} \n".format(i, name, key))
-            f.close()
-        print "Find list of stops in your tools folder (stops.txt)"
-        print "Enter stop id for raid (from file)\n>",
-    else:
-        print "Here is a list of stops found in your cache:"
-        i = 0
-        for key, name in _gym_info.items():
-            i += 1
-            print "[{}] {} : {} ".format(i, name, key)
-        print "Enter stop id (from above)\n>",
-
-
 def gym_cache():
     print "Do you use file caching or does 'gym name' matter? (Y/N)\n>",
     if raw_input() in truthy:
@@ -308,18 +264,6 @@ def gym_cache():
         cache_or_invalid()
         list_gyms()
         gym_or_invalid("gym_id", "gym_name")
-
-
-def stop_cache():
-    print "Do you use file caching or does 'stop name' matter? (Y/N)\n>",
-    if raw_input() in truthy:
-        if not list_cache():
-            return False
-        print "Enter cache file name to verify the stop (default:manager_0)" \
-              "\n>",
-        cache_or_invalid()
-        list_stops()
-        stop_or_invalid("pokestop_id", "pokestop_name")
 
 
 def reset_timers_and_encounters():
@@ -491,7 +435,6 @@ elif type == whtypes["6"]:
           day_or_night_formatted + '\n>',
     int_or_default("world_time")
 elif type == whtypes["7"]:
-    stop_cache()
     print "What quest type is it? (Default: 0)\n" + quest_types_formatted + \
           '\n>',
     int_or_default('type')
@@ -522,7 +465,6 @@ while True:
             raise requests.exceptions.RequestException(
                 "Response received {}, webhook not accepted.".format(
                     resp.status_code))
-            print "Attempting connection again"
     print "Send again?\n>",
     if raw_input() not in truthy:
         break

--- a/tools/webhook_test.py
+++ b/tools/webhook_test.py
@@ -162,8 +162,8 @@ def set_init(webhook_type):
             "type": "quest",
             "message": {
                 "pokestop_id": current_time,
-                "name": "Stop Name",
-                "url": "http://placehold.it/500x500",
+                "pokestop_name": "Stop Name",
+                "pokestop_url": "http://placehold.it/500x500",
                 "latitude": 37.7876146,
                 "longitude": -122.390624,
                 "quest": "Catch 10 Dragonites",


### PR DESCRIPTION
## Description
Ability to process quests sent to webhook.

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
Since scans are down nobody has worked on including quests in PA. My map now sends a quest webhook when a user submitted a new quest found so needed to process these in PA. Because these quests are not sent by scans, the information that we can send to the webhook is quite limited. Basically, the stop information and the text of the quest description and reward is sent. The expiry is dynamically calculated (23:59 tonight). Because it is just text that is sent, those requiring localization will need to ensure that the information is sent ALREADY TRANSLATED.

## How Has This Been Tested?
Has been tested and has been running on my prod environment for weeks, BUT......

My fork has not been updated to latest patch and is therefore behind the dev branch here. I have tested using latest for about 10 quests without any filters and it works, but needs serious further testing. Also, the following needs doing:

1. caching
2. filter testing (not tested at all)
3. unit tests
4. documentation