### PR TITLE
Support for Ex Raid Eligibility

### DIFF
--- a/PokeAlarm/Events/EggEvent.py
+++ b/PokeAlarm/Events/EggEvent.py
@@ -45,10 +45,13 @@ class EggEvent(BaseEvent):
             str, data.get('description'), Unknown.REGULAR).strip()
         self.gym_image = check_for_none(
             str, data.get('url'), Unknown.REGULAR)
+
         self.sponsor_id = check_for_none(
             int, data.get('sponsor'), Unknown.TINY)
         self.park = check_for_none(
             str, data.get('park'), Unknown.REGULAR)
+        self.ex_eligible = check_for_none(
+            int, data.get('is_ex_raid_eligible'), Unknown.REGULAR)
 
         # Gym Team (this is only available from cache)
         self.current_team_id = check_for_none(
@@ -105,6 +108,9 @@ class EggEvent(BaseEvent):
             'sponsored':
                 self.sponsor_id > 0
                 if Unknown.is_not(self.sponsor_id) else Unknown.REGULAR,
+            'ex_eligible':
+                self.ex_eligible > 0 if Unknown.is_not(self.ex_eligible)
+                else Unknown.REGULAR,
             'park': self.park,
             'team_id': self.current_team_id,
             'team_name': locale.get_team_name(self.current_team_id),

--- a/PokeAlarm/Events/GymEvent.py
+++ b/PokeAlarm/Events/GymEvent.py
@@ -35,6 +35,8 @@ class GymEvent(BaseEvent):
             str, data.get('description'), Unknown.REGULAR).strip()
         self.gym_image = check_for_none(
             str, data.get('url'), Unknown.REGULAR)
+        self.ex_eligible = check_for_none(
+            int, data.get('is_ex_raid_eligible'), Unknown.REGULAR)
 
         # Gym Guards
         self.slots_available = check_for_none(
@@ -69,6 +71,7 @@ class GymEvent(BaseEvent):
             'waze': get_waze_link(self.lat, self.lng),
             'geofence': self.geofence,
 
+
             # Team Info
             'old_team': locale.get_team_name(self.old_team_id),
             'old_team_id': self.old_team_id,
@@ -81,6 +84,9 @@ class GymEvent(BaseEvent):
             'gym_name': self.gym_name,
             'gym_description': self.gym_description,
             'gym_image': self.gym_image,
+            'ex_eligible':
+                self.ex_eligible > 0 if Unknown.is_not(self.ex_eligible)
+                else Unknown.REGULAR,
 
             # Guards
             'slots_available': self.slots_available,

--- a/PokeAlarm/Events/RaidEvent.py
+++ b/PokeAlarm/Events/RaidEvent.py
@@ -80,10 +80,13 @@ class RaidEvent(BaseEvent):
             str, data.get('description'), Unknown.REGULAR).strip()
         self.gym_image = check_for_none(
             str, data.get('url'), Unknown.REGULAR)
+
         self.sponsor_id = check_for_none(
             int, data.get('sponsor'), Unknown.TINY)
         self.park = check_for_none(
             str, data.get('park'), Unknown.REGULAR)
+        self.ex_eligible = check_for_none(
+            int, data.get('is_ex_raid_eligible'), Unknown.REGULAR)
 
         # Gym Team (this is only available from cache)
         self.current_team_id = check_for_none(
@@ -216,6 +219,9 @@ class RaidEvent(BaseEvent):
             'sponsor_id': self.sponsor_id,
             'sponsored':
                 self.sponsor_id > 0 if Unknown.is_not(self.sponsor_id)
+                else Unknown.REGULAR,
+            'ex_eligible':
+                self.ex_eligible > 0 if Unknown.is_not(self.ex_eligible)
                 else Unknown.REGULAR,
             'park': self.park,
             'team_id': self.current_team_id,

--- a/PokeAlarm/Filters/EggFilter.py
+++ b/PokeAlarm/Filters/EggFilter.py
@@ -62,6 +62,12 @@ class EggFilter(BaseFilter):
             limit=BaseFilter.parse_as_set(
                 GymUtils.create_regex, 'park_contains', data))
 
+        self.is_ex_eligible = self.evaluate_attribute(
+            event_attribute='ex_eligible',
+            eval_func=operator.eq,
+            limit=BaseFilter.parse_as_type(bool, 'is_ex_eligible', data)
+        )
+
         # Team Info
         self.old_team = self.evaluate_attribute(  # f.ctis contains m.cti
             event_attribute='current_team_id', eval_func=operator.contains,

--- a/PokeAlarm/Filters/GymFilter.py
+++ b/PokeAlarm/Filters/GymFilter.py
@@ -41,6 +41,11 @@ class GymFilter(BaseFilter):
             eval_func=GymUtils.not_match_regex_dict,
             limit=BaseFilter.parse_as_set(
                 GymUtils.create_regex, 'gym_name_excludes', data))
+        self.is_ex_eligible = self.evaluate_attribute(
+            event_attribute='ex_eligible',
+            eval_func=operator.eq,
+            limit=BaseFilter.parse_as_type(bool, 'is_ex_eligible', data)
+        )
 
         # Slots Available
         self.min_slots = self.evaluate_attribute(

--- a/PokeAlarm/Filters/RaidFilter.py
+++ b/PokeAlarm/Filters/RaidFilter.py
@@ -96,6 +96,12 @@ class RaidFilter(BaseFilter):
             limit=BaseFilter.parse_as_set(
                 GymUtils.create_regex, 'park_contains', data))
 
+        self.is_ex_eligible = self.evaluate_attribute(
+            event_attribute='ex_eligible',
+            eval_func=operator.eq,
+            limit=BaseFilter.parse_as_type(bool, 'is_ex_eligible', data)
+        )
+
         # Team Info
         self.old_team = self.evaluate_attribute(  # f.ctis contains m.cti
             event_attribute='current_team_id', eval_func=operator.contains,

--- a/tests/filters/test_egg_filter.py
+++ b/tests/filters/test_egg_filter.py
@@ -33,7 +33,8 @@ class TestEggFilter(unittest.TestCase):
             "latitude": 37.7876146,
             "longitude": -122.390624,
             "sponsor": None,
-            "park": None
+            "park": None,
+            "is_ex_raid_eligible": None
         }
         settings.update(values)
         return Events.EggEvent(settings)
@@ -143,6 +144,22 @@ class TestEggFilter(unittest.TestCase):
             t = time.mktime(d.timetuple())
             event = self.gen_event({"start": t})
             self.assertFalse(filt.check_event(event))
+
+    def test_is_ex_eligible(self):
+        # Create the filters
+        eligible = self.gen_filter({"is_ex_eligible": True})
+        not_eligible = self.gen_filter({"is_ex_eligible": False})
+
+        ex_event = self.gen_event({"is_ex_raid_eligible": True})
+        not_ex_event = self.gen_event({"is_ex_raid_eligible": False})
+
+        # Test passing
+        self.assertTrue(eligible.check_event(ex_event))
+        self.assertTrue(not_eligible.check_event(not_ex_event))
+
+        # Test failing
+        self.assertFalse(eligible.check_event(not_ex_event))
+        self.assertFalse(not_eligible.check_event(ex_event))
 
 
 if __name__ == '__main__':

--- a/tests/filters/test_gym_filter.py
+++ b/tests/filters/test_gym_filter.py
@@ -87,7 +87,8 @@ class TestGymFilter(unittest.TestCase):
                 "trainer_level": 23,
                 "cp": 1670,
                 "iv_stamina": 11,
-                "cp_decayed": 1435
+                "cp_decayed": 1435,
+                "is_ex_raid_eligible": None
             }]
         }
         settings.update(values)
@@ -155,6 +156,22 @@ class TestGymFilter(unittest.TestCase):
         for dist in [0, 300, 3000]:
             gym.distance = dist
             self.assertFalse(filt.check_event(gym))
+
+    def test_is_ex_eligible(self):
+        # Create the filters
+        eligible = self.gen_filter({"is_ex_eligible": True})
+        not_eligible = self.gen_filter({"is_ex_eligible": False})
+
+        ex_event = self.gen_event({"is_ex_raid_eligible": True})
+        not_ex_event = self.gen_event({"is_ex_raid_eligible": False})
+
+        # Test passing
+        self.assertTrue(eligible.check_event(ex_event))
+        self.assertTrue(not_eligible.check_event(not_ex_event))
+
+        # Test failing
+        self.assertFalse(eligible.check_event(not_ex_event))
+        self.assertFalse(not_eligible.check_event(ex_event))
 
 
 if __name__ == '__main__':

--- a/tests/filters/test_raid_filter.py
+++ b/tests/filters/test_raid_filter.py
@@ -37,7 +37,8 @@ class TestRaidFilter(unittest.TestCase):
             "latitude": 37.7876146,
             "longitude": -122.390624,
             "sponsor": None,
-            "park": None
+            "park": None,
+            "is_ex_raid_eligible": None
         }
         settings.update(values)
         return Events.RaidEvent(settings)
@@ -182,6 +183,22 @@ class TestRaidFilter(unittest.TestCase):
             t = time.mktime(d.timetuple())
             event = self.gen_event({"end": t})
             self.assertFalse(filt.check_event(event))
+
+    def test_is_ex_eligible(self):
+        # Create the filters
+        eligible = self.gen_filter({"is_ex_eligible": True})
+        not_eligible = self.gen_filter({"is_ex_eligible": False})
+
+        ex_event = self.gen_event({"is_ex_raid_eligible": True})
+        not_ex_event = self.gen_event({"is_ex_raid_eligible": False})
+
+        # Test passing
+        self.assertTrue(eligible.check_event(ex_event))
+        self.assertTrue(not_eligible.check_event(not_ex_event))
+
+        # Test failing
+        self.assertFalse(eligible.check_event(not_ex_event))
+        self.assertFalse(not_eligible.check_event(ex_event))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added 'ex_eligible' parameter from the webhook field 'is_ex_raid_eligible' to Gym, Egg, and Raid events. Accepts a boolean value. 

Added 'is_ex_eligible' to Gym, Egg, and Raid filters. Accepts a boolean value. 