### PR TITLE
Raid form filter

### DIFF
--- a/PokeAlarm/Filters/RaidFilter.py
+++ b/PokeAlarm/Filters/RaidFilter.py
@@ -54,6 +54,11 @@ class RaidFilter(BaseFilter):
             event_attribute='raid_lvl', eval_func=operator.ge,
             limit=BaseFilter.parse_as_type(int, 'max_raid_lvl', data))
 
+        # Monster Forms
+        self.forms = self.evaluate_attribute(  # f.forms in r.form_id
+            event_attribute='form_id', eval_func=operator.contains,
+            limit=BaseFilter.parse_as_set(int, 'form_ids', data))
+
         # CP
         self.min_cp = self.evaluate_attribute(  # f.min_cp <= r.cp
             event_attribute='cp', eval_func=operator.le,
@@ -147,6 +152,10 @@ class RaidFilter(BaseFilter):
             settings['min_lvl'] = self.min_lvl
         if self.max_lvl is not None:
             settings['max_lvl'] = self.max_lvl
+
+        # Form
+        if self.forms is not None:
+            settings['forms'] = self.forms
 
         # Weather
         if self.weather_ids is not None:

--- a/docs/configuration/filters/raid-filters.rst
+++ b/docs/configuration/filters/raid-filters.rst
@@ -47,6 +47,7 @@ min_raid_lvl      Minimum level of the raid.                       ``0``
 max_raid_lvl      Maximum level of the raid.                       ``5``
 min_cp            Minimum CP of the monster.                       ``0``
 max_cp            Maximum CP of the monster.                       ``100000``
+form_ids          Array of allowed form ids for the monster.       ``[0,"1"]``
 quick_moves       Accepted quick moves, by id or name.             ``["Vine Whip","Tackle"]``
 charge_moves      Accepted charge moves, by id or name.            ``["Sludge Bomb","Seed Bomb"]``
 current_teams     List of allowed current teams, by id or name.    ``["Instinct","Mystic"]``

--- a/tests/filters/test_raid_filter.py
+++ b/tests/filters/test_raid_filter.py
@@ -106,6 +106,13 @@ class TestRaidFilter(unittest.TestCase):
         self.pass_vals = [1, 2, 3]
         self.fail_vals = [0]
 
+    @generic_filter_test
+    def test_form_id(self):
+        self.filt = {'form_ids': [1, '2', 67]}
+        self.event_key = 'form'
+        self.pass_vals = [1, 2, 67]
+        self.fail_vals = [0]
+
     def test_sponsored(self):
         # Create the filters
         filter1 = self.gen_filter({"sponsored": False})

--- a/tools/webhook_test.py
+++ b/tools/webhook_test.py
@@ -134,6 +134,7 @@ def set_init(webhook_type):
                 "gym_id": current_time,
                 "gym_name": "unknown",
                 "pokemon_id": 150,
+                "form": 0,
                 "cp": 12345,
                 "move_1": 123,
                 "move_2": 123,
@@ -413,6 +414,8 @@ elif type == whtypes["5"]:
     gym_cache()
     print "Enter pokemon id for raid\n>",
     int_or_default("pokemon_id")
+    print "Enter form id for raid monster\n>",
+    int_or_default("form")
     print "Which team?(put in a number)\n" + teams_formatted + "\n>",
     get_and_validate_team()
     print "Moveset important?\n>",


### PR DESCRIPTION
## Description
Adds filtering by form id on raids

This is a super minimal implementation. This *does not* include form name filtering, just filtering by the id

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
Lots of people want to filter by alolan raids, which you can't do without some sort of form filter

## How Has This Been Tested?
Locally only, Windows 10

## Wiki Update
- [x] This change requires an update to the Wiki.
- [ ] This change does not require an update to the Wiki.

Wiki update rolled into PR