### PR TITLE
Time DTS without seconds

### DIFF
--- a/PokeAlarm/Events/EggEvent.py
+++ b/PokeAlarm/Events/EggEvent.py
@@ -79,6 +79,14 @@ class EggEvent(BaseEvent):
             '12h_raid_end': raid_end_time[1],
             '24h_raid_end': raid_end_time[2],
 
+            # Time Remaining Without Seconds
+            'hatch_time_left_minutes': hatch_time[3],
+            '12h_hatch_time_minutes': hatch_time[4],
+            '24h_hatch_time_minutes': hatch_time[5],
+            'raid_time_left_minutes': raid_end_time[3],
+            '12h_raid_end_minutes': raid_end_time[4],
+            '24h_raid_end_minutes': raid_end_time[5],
+
             # Location
             'lat': self.lat,
             'lng': self.lng,

--- a/PokeAlarm/Events/EggEvent.py
+++ b/PokeAlarm/Events/EggEvent.py
@@ -71,21 +71,27 @@ class EggEvent(BaseEvent):
             # Identification
             'gym_id': self.gym_id,
 
-            # Time Remaining
+            # Hatch Time Remaining
             'hatch_time_left': hatch_time[0],
             '12h_hatch_time': hatch_time[1],
             '24h_hatch_time': hatch_time[2],
+            'hatch_time_no_secs': hatch_time[3],
+            '12h_hatch_time_no_secs': hatch_time[4],
+            '24h_hatch_time_no_secs': hatch_time[5],
+            'hatch_time_raw_hours': hatch_time[6],
+            'hatch_time_raw_minutes': hatch_time[7],
+            'hatch_time_raw_seconds': hatch_time[8],
+
+            # Raid Time Remaining
             'raid_time_left': raid_end_time[0],
             '12h_raid_end': raid_end_time[1],
             '24h_raid_end': raid_end_time[2],
-
-            # Time Remaining Without Seconds
-            'hatch_time_left_minutes': hatch_time[3],
-            '12h_hatch_time_minutes': hatch_time[4],
-            '24h_hatch_time_minutes': hatch_time[5],
-            'raid_time_left_minutes': raid_end_time[3],
-            '12h_raid_end_minutes': raid_end_time[4],
-            '24h_raid_end_minutes': raid_end_time[5],
+            'raid_time_no_secs': raid_end_time[3],
+            '12h_raid_end_no_secs': raid_end_time[4],
+            '24h_raid_end_no_secs': raid_end_time[5],
+            'raid_time_raw_hours': raid_end_time[6],
+            'raid_time_raw_minutes': raid_end_time[7],
+            'raid_time_raw_seconds': raid_end_time[8],
 
             # Location
             'lat': self.lat,

--- a/PokeAlarm/Events/MonEvent.py
+++ b/PokeAlarm/Events/MonEvent.py
@@ -149,11 +149,12 @@ class MonEvent(BaseEvent):
             'time_left': time[0],
             '12h_time': time[1],
             '24h_time': time[2],
-
-            # Time Remaining Without Seconds
-            'time_left_minutes': time[3],
-            '12h_time_minutes': time[4],
-            '24h_time_minutes': time[5],
+            'time_left_no_secs': time[3],
+            '12h_time_no_secs': time[4],
+            '24h_time_no_secs': time[5],
+            'time_left_raw_hours': time[6],
+            'time_left_raw_minutes': time[7],
+            'time_left_raw_seconds': time[8],
 
             # Spawn Data
             'spawn_start': self.spawn_start,

--- a/PokeAlarm/Events/MonEvent.py
+++ b/PokeAlarm/Events/MonEvent.py
@@ -150,6 +150,11 @@ class MonEvent(BaseEvent):
             '12h_time': time[1],
             '24h_time': time[2],
 
+            # Time Remaining Without Seconds
+            'time_left_minutes': time[3],
+            '12h_time_minutes': time[4],
+            '24h_time_minutes': time[5],
+
             # Spawn Data
             'spawn_start': self.spawn_start,
             'spawn_end': self.spawn_end,

--- a/PokeAlarm/Events/RaidEvent.py
+++ b/PokeAlarm/Events/RaidEvent.py
@@ -122,9 +122,14 @@ class RaidEvent(BaseEvent):
             '24h_raid_end': raid_end_time[2],
 
             # Time Remaining Without Seconds
-            'raid_time_left_minutes': raid_end_time[3],
-            '12h_raid_end_minutes': raid_end_time[4],
-            '24h_raid_end_minutes': raid_end_time[5],
+            'raid_time_no_secs': raid_end_time[3],
+            '12h_raid_end_no_secs': raid_end_time[4],
+            '24h_raid_end_no_secs': raid_end_time[5],
+
+            # Raw time remaining values
+            'raid_time_raw_hours': raid_end_time[6],
+            'raid_time_raw_minutes': raid_end_time[7],
+            'raid_time_raw_seconds': raid_end_time[8],
 
             # Type
             'type1': type1,

--- a/PokeAlarm/Events/RaidEvent.py
+++ b/PokeAlarm/Events/RaidEvent.py
@@ -121,6 +121,11 @@ class RaidEvent(BaseEvent):
             '12h_raid_end': raid_end_time[1],
             '24h_raid_end': raid_end_time[2],
 
+            # Time Remaining Without Seconds
+            'raid_time_left_minutes': raid_end_time[3],
+            '12h_raid_end_minutes': raid_end_time[4],
+            '24h_raid_end_minutes': raid_end_time[5],
+
             # Type
             'type1': type1,
             'type1_or_empty': Unknown.or_empty(type1),

--- a/PokeAlarm/Events/StopEvent.py
+++ b/PokeAlarm/Events/StopEvent.py
@@ -51,6 +51,11 @@ class StopEvent(BaseEvent):
             '12h_time': time[1],
             '24h_time': time[2],
 
+            # Time Left Without Seconds
+            'time_left_minutes': time[3],
+            '12h_time_minutes': time[4],
+            '24h_time_minutes': time[5],
+
             # Location
             'lat': self.lat,
             'lng': self.lng,

--- a/PokeAlarm/Events/StopEvent.py
+++ b/PokeAlarm/Events/StopEvent.py
@@ -50,11 +50,12 @@ class StopEvent(BaseEvent):
             'time_left': time[0],
             '12h_time': time[1],
             '24h_time': time[2],
-
-            # Time Left Without Seconds
-            'time_left_minutes': time[3],
-            '12h_time_minutes': time[4],
-            '24h_time_minutes': time[5],
+            'time_left_no_secs': time[3],
+            '12h_time_no_secs': time[4],
+            '24h_time_no_secs': time[5],
+            'time_left_raw_hours': time[6],
+            'time_left_raw_minutes': time[7],
+            'time_left_raw_seconds': time[8],
 
             # Location
             'lat': self.lat,

--- a/PokeAlarm/Utils.py
+++ b/PokeAlarm/Utils.py
@@ -475,21 +475,26 @@ def get_time_as_str(t, timezone=None):
     else:
         disappear_time = datetime.now() + d
     # Time remaining in minutes and seconds
-    time_left = "%dm %ds" % (m, s) if h == 0 else "%dh %dm" % (h, m)
+    time = "%dm %ds" % (m, s) if h == 0 else "%dh %dm" % (h, m)
     # Disappear time in 12h format, eg "2:30:16 PM"
-    time_12 = disappear_time.strftime("%I:%M:%S") \
+    time_12h = disappear_time.strftime("%I:%M:%S") \
         + disappear_time.strftime("%p").lower()
     # Disappear time in 24h format including seconds, eg "14:30:16"
-    time_24 = disappear_time.strftime("%H:%M:%S")
+    time_24h = disappear_time.strftime("%H:%M:%S")
 
     # Get the same as above but without seconds
-    time_left_minutes = "%dm" % m if h == 0 else "%dh %dm" % (h, m)
-    time_12_minutes = disappear_time.strftime("%I:%M") \
+    time_no_sec = "%dm" % m if h == 0 else "%dh %dm" % (h, m)
+    time_12h_no_sec = disappear_time.strftime("%I:%M") \
         + disappear_time.strftime("%p").lower()
-    time_24_minutes = disappear_time.strftime("%H:%M")
+    time_24h_no_sec = disappear_time.strftime("%H:%M")
 
-    return time_left, time_12, time_24, \
-        time_left_minutes, time_12_minutes, time_24_minutes
+    time_raw_hours = int(h)
+    time_raw_minutes = int(m)
+    time_raw_seconds = int(s)
+
+    return time, time_12h, time_24h, \
+        time_no_sec, time_12h_no_sec, time_24h_no_sec, \
+        time_raw_hours, time_raw_minutes, time_raw_seconds
 
 
 # Return the time in seconds

--- a/PokeAlarm/Utils.py
+++ b/PokeAlarm/Utils.py
@@ -481,7 +481,15 @@ def get_time_as_str(t, timezone=None):
         + disappear_time.strftime("%p").lower()
     # Disappear time in 24h format including seconds, eg "14:30:16"
     time_24 = disappear_time.strftime("%H:%M:%S")
-    return time_left, time_12, time_24
+
+    # Get the same as above but without seconds
+    time_left_minutes = "%dm" % m if h == 0 else "%dh %dm" % (h, m)
+    time_12_minutes = disappear_time.strftime("%I:%M") \
+        + disappear_time.strftime("%p").lower()
+    time_24_minutes = disappear_time.strftime("%H:%M")
+
+    return time_left, time_12, time_24, \
+        time_left_minutes, time_12_minutes, time_24_minutes
 
 
 # Return the time in seconds

--- a/docs/configuration/events/egg-events.rst
+++ b/docs/configuration/events/egg-events.rst
@@ -75,22 +75,28 @@ geofence            Geofence around the event.
 Time
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-======================= ===============================================================
-DTS                     Description
-======================= ===============================================================
-hatch_time_left         Time remaining until the egg hatches.
-12h_hatch_time          Time when the egg will hatch, formatted in 12h.
-24h_hatch_time          Time when the egg will hatch, formatted in 24h.
-raid_time_left          Time remaining until the raid ends.
-12h_raid_end            Time when the raid ends, formatted in 12h.
-24h_raid_end            Time when the raid ends, formatted in 24h.
-hatch_time_left_minutes Time remaining until the egg hatches without seconds.
-12_hatch_time_minutes   Time when the egg will hatch, formatted in 12h without seconds.
-24h_hatch_time_minutes  Time when the egg will hatch, formatted in 24h without seconds.
-raid_time_left_minutes  Time remaining until the raid ends without seconds.
-12h_raid_end_minutes    Time when the raid ends, formatted in 12h without seconds.
-24h_raid_end_minutes    Time when the raid ends, formatted in 24h without seconds.
-======================= ===============================================================
+======================= =============================================================== =============
+DTS                     Description                                                     Example
+======================= =============================================================== =============
+hatch_time_left         Time remaining until the egg hatches.                           1h 52m 15s
+12h_hatch_time          Time when the egg will hatch, formatted in 12h.                 01:15:15pm
+24h_hatch_time          Time when the egg will hatch, formatted in 24h.                 13:15:15
+hatch_time_no_secs      Time remaining until the egg hatches without seconds.           1h 52m
+12_hatch_time_no_secs   Time when the egg will hatch, formatted in 12h without seconds. 01:15pm
+24h_hatch_time_no_secs  Time when the egg will hatch, formatted in 24h without seconds. 13:15
+hatch_time_raw_hours    Hours only until the egg will hatch.                            1
+hatch_time_raw_minutes  Minutes only until the egg will hatch.                          52
+hatch_time_raw_seconds  Seconds only until the egg will hatch.                          29
+raid_time_left          Time remaining until the raid ends.                             1h 52m 12s
+12h_raid_end            Time when the raid ends, formatted in 12h.                      01:15:15pm
+24h_raid_end            Time when the raid ends, formatted in 24h.                      13:15:15
+raid_time_no_secs       Time remaining until the raid ends without seconds.             1h 52m
+12h_raid_end_no_secs    Time when the raid ends, formatted in 12h without seconds.      01:15pm
+24h_raid_end_no_secs    Time when the raid ends, formatted in 24h without seconds.      13:15
+raid_time_raw_hours     Hours only until the raid will end.                             1
+raid_time_raw_minutes   Minutes only until the raid will end.                           52
+raid_time_raw_seconds   Seconds only until the raid will end.                           29
+======================= =============================================================== =============
 
 
 Weather

--- a/docs/configuration/events/egg-events.rst
+++ b/docs/configuration/events/egg-events.rst
@@ -75,16 +75,22 @@ geofence            Geofence around the event.
 Time
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-================= =========================================================
-DTS               Description
-================= =========================================================
-hatch_time_left   Time remaining until the egg hatches.
-12h_hatch_time    Time when the egg will hatch, formatted in 12h.
-24h_hatch_time    Time when the egg will hatch, formatted in 24h.
-raid_time_left    Time remaining until the raid ends.
-12h_raid_end      Time when the raid ends, formatted in 12h.
-24h_raid_end      Time when the raid ends, formatted in 24h.
-================= =========================================================
+======================= ===============================================================
+DTS                     Description
+======================= ===============================================================
+hatch_time_left         Time remaining until the egg hatches.
+12h_hatch_time          Time when the egg will hatch, formatted in 12h.
+24h_hatch_time          Time when the egg will hatch, formatted in 24h.
+raid_time_left          Time remaining until the raid ends.
+12h_raid_end            Time when the raid ends, formatted in 12h.
+24h_raid_end            Time when the raid ends, formatted in 24h.
+hatch_time_left_minutes Time remaining until the egg hatches without seconds.
+12_hatch_time_minutes   Time when the egg will hatch, formatted in 12h without seconds.
+24h_hatch_time_minutes  Time when the egg will hatch, formatted in 24h without seconds.
+raid_time_left_minutes  Time remaining until the raid ends without seconds.
+12h_raid_end_minutes    Time when the raid ends, formatted in 12h without seconds.
+24h_raid_end_minutes    Time when the raid ends, formatted in 24h without seconds.
+======================= ===============================================================
 
 
 Weather

--- a/docs/configuration/events/monster-events.rst
+++ b/docs/configuration/events/monster-events.rst
@@ -180,13 +180,19 @@ geofence            Geofence around the event.
 Time
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-=================== ============================================================
-DTS                 Description
-=================== ============================================================
-time_left           Time remaining until the monster expires.
-12h_time            Time that the monster will disappear, in a 12h format.
-24h_time            Time that the monster will disappear, in a 24h format.
-=================== ============================================================
+===================== ======================================================================= ============
+DTS                   Description                                                             Example
+===================== ======================================================================= ============
+time_left             Time remaining until the monster expires.                               1h 15m 52s
+12h_time              Time that the monster will disappear, in a 12h format.                  01:15:52pm
+24h_time              Time that the monster will disappear, in a 24h format.                  13:15:52
+time_left_no_secs     Time remaining until the monster expires without seconds.               1h 15m
+12h_time_no_secs      Time that the monster will disappear, in a 12h format, without seconds. 01:15pm
+24h_time_no_secs      Time that the monster will disappear, in a 24h format, without seconds. 13:15
+time_left_raw_hours   Hours only until the monster expires.                                   1
+time_left_raw_minutes Minutes only until the monster expires.                                 15
+time_left_raw_seconds Seconds only until the monster expires.                                 52
+===================== ======================================================================= ============
 
 
 Weather

--- a/docs/configuration/events/raid-events.rst
+++ b/docs/configuration/events/raid-events.rst
@@ -138,13 +138,16 @@ geofence      Geofence around the event.
 Time
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-================ ===============================================
-DTS              Description
-================ ===============================================
-raid_time_left   Time remaining until the raid ends.
-12h_raid_end     Time when the raid ends, formatted in 12h.
-24h_raid_end     Time when the raid ends, formatted in 24h.
-================ ===============================================
+======================== ==========================================================
+DTS                      Description
+======================== ==========================================================
+raid_time_left           Time remaining until the raid ends.
+12h_raid_end             Time when the raid ends, formatted in 12h.
+24h_raid_end             Time when the raid ends, formatted in 24h.
+raid_time_left_minutes   Time remaining until the raid ends without seconds.
+12h_raid_end_minutes     Time when the raid ends, formatted in 12h without seconds.
+24h_raid_end_minutes     Time when the raid ends, formatted in 24h without seconds.
+======================== ==========================================================
 
 
 Weather

--- a/docs/configuration/events/raid-events.rst
+++ b/docs/configuration/events/raid-events.rst
@@ -138,16 +138,19 @@ geofence      Geofence around the event.
 Time
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-======================== ==========================================================
-DTS                      Description
-======================== ==========================================================
-raid_time_left           Time remaining until the raid ends.
-12h_raid_end             Time when the raid ends, formatted in 12h.
-24h_raid_end             Time when the raid ends, formatted in 24h.
-raid_time_left_minutes   Time remaining until the raid ends without seconds.
-12h_raid_end_minutes     Time when the raid ends, formatted in 12h without seconds.
-24h_raid_end_minutes     Time when the raid ends, formatted in 24h without seconds.
-======================== ==========================================================
+======================== ========================================================== ============
+DTS                      Description                                                Example
+======================== ========================================================== ============
+raid_time_left           Time remaining until the raid ends.                        1h 52m 17s
+12h_raid_end             Time when the raid ends, formatted in 12h.                 01:15:52pm
+24h_raid_end             Time when the raid ends, formatted in 24h.                 13:15:52
+raid_time_no_secs        Time remaining until the raid ends without seconds.        1h 52m
+12h_raid_end_no_secs     Time when the raid ends, formatted in 12h without seconds. 01:15pm
+24h_raid_end_no_secs     Time when the raid ends, formatted in 24h without seconds. 13:15
+raid_time_raw_hours      Hours only until the raid will end.                        1
+raid_time_raw_minutes    Minutes only until the raid will end.                      52
+raid_time_raw_seconds    Seconds only until the raid will end.                      15
+======================== ========================================================== ============
 
 
 Weather

--- a/docs/configuration/events/stop-events.rst
+++ b/docs/configuration/events/stop-events.rst
@@ -63,13 +63,16 @@ geofence     Geofence around the event.
 Time
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-==================== ===================================================================
-DTS                  Description
-==================== ===================================================================
-time_left            Time remaining until the lure expires.
-12h_time             Time that the lure will disappear, in a 12h format.
-24h_time             Time that the lure will disappear, in a 24h format.
-time_left_minutes    Time remaining until the lure expires without seconds.
-12h_time_minutes     Time that the lure will disappear, in a 12h format without seconds.
-24h_time_minutes     Time that the lure will disappear, in a 24h format without seconds.
-==================== ===================================================================
+===================== =================================================================== ===========
+DTS                   Description                                                         Example
+===================== =================================================================== ===========
+time_left             Time remaining until the lure expires.                              1h 15m 52s
+12h_time              Time that the lure will disappear, in a 12h format.                 01:15:52pm
+24h_time              Time that the lure will disappear, in a 24h format.                 13:15:52
+time_left_no_secs     Time remaining until the lure expires without seconds.              1h 15m
+12h_time_no_secs      Time that the lure will disappear, in a 12h format without seconds. 01:15pm
+24h_time_no_secs      Time that the lure will disappear, in a 24h format without seconds. 13:15
+time_left_raw_hours   Hours only until the lure expires.                                  1
+time_left_raw_minutes Minutes only until the lure expires.                                15
+time_left_raw_seconds Seconds only until the lure expires.                                52
+===================== =================================================================== ===========

--- a/docs/configuration/events/stop-events.rst
+++ b/docs/configuration/events/stop-events.rst
@@ -63,10 +63,13 @@ geofence     Geofence around the event.
 Time
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-============ ====================================================
-DTS          Description
-============ ====================================================
-time_left    Time remaining until the lure expires.
-12h_time     Time that the lure will disappear, in a 12h format.
-24h_time     Time that the lure will disappear, in a 24h format.
-============ ====================================================
+==================== ===================================================================
+DTS                  Description
+==================== ===================================================================
+time_left            Time remaining until the lure expires.
+12h_time             Time that the lure will disappear, in a 12h format.
+24h_time             Time that the lure will disappear, in a 24h format.
+time_left_minutes    Time remaining until the lure expires without seconds.
+12h_time_minutes     Time that the lure will disappear, in a 12h format without seconds.
+24h_time_minutes     Time that the lure will disappear, in a 24h format without seconds.
+==================== ===================================================================


### PR DESCRIPTION
## Description
Time DTS without seconds
In the case of hours being available, it will show hours as well as minutes
Includes documentation update

This was a frequently asked for feature

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
Frequently requested.
Some people don't like the seconds on the end
It also makes PA compatible with other tools

## How Has This Been Tested?
Locally, Windows 10

## Wiki Update
- [x] This change requires an update to the Wiki.
- [ ] This change does not require an update to the Wiki.