### PR TITLE
Add gender field support for raid event

### DIFF
--- a/PokeAlarm/Events/RaidEvent.py
+++ b/PokeAlarm/Events/RaidEvent.py
@@ -3,6 +3,7 @@ from datetime import datetime
 # 3rd Party Imports
 # Local Imports
 from PokeAlarm import Unknown
+from PokeAlarm.Utilities import MonUtils
 from . import BaseEvent
 from PokeAlarm.Utils import get_gmaps_link, get_applemaps_link, \
     get_time_as_str, get_move_type, get_move_damage, get_move_dps, \
@@ -39,6 +40,8 @@ class RaidEvent(BaseEvent):
         self.cp = int(data['cp'])
         self.types = get_base_types(self.mon_id)
         self.boss_level = 20
+        self.gender = MonUtils.get_gender_sym(
+            check_for_none(int, data.get('gender'), Unknown.TINY))
 
         # Form
         self.form_id = check_for_none(int, data.get('form'), 0)
@@ -193,6 +196,7 @@ class RaidEvent(BaseEvent):
             'mon_name': locale.get_pokemon_name(self.mon_id),
             'mon_id': self.mon_id,
             'mon_id_3': "{:03}".format(self.mon_id),
+            'gender': self.gender,
             # TODO: Form?
 
             # Quick Move

--- a/PokeAlarm/Filters/RaidFilter.py
+++ b/PokeAlarm/Filters/RaidFilter.py
@@ -59,6 +59,12 @@ class RaidFilter(BaseFilter):
             event_attribute='form_id', eval_func=operator.contains,
             limit=BaseFilter.parse_as_set(int, 'form_ids', data))
 
+        # Gender
+        self.genders = self.evaluate_attribute(  # f.genders contains m.gender
+            event_attribute='gender', eval_func=operator.contains,
+            limit=BaseFilter.parse_as_set(
+                MonUtils.get_gender_sym, 'genders', data))
+
         # CP
         self.min_cp = self.evaluate_attribute(  # f.min_cp <= r.cp
             event_attribute='cp', eval_func=operator.le,
@@ -156,6 +162,10 @@ class RaidFilter(BaseFilter):
         # Form
         if self.forms is not None:
             settings['forms'] = self.forms
+
+        # Gender
+        if self.genders is not None:
+            settings['genders'] = self.genders
 
         # Weather
         if self.weather_ids is not None:

--- a/docs/configuration/events/raid-events.rst
+++ b/docs/configuration/events/raid-events.rst
@@ -108,6 +108,7 @@ costume            Costume name of the monster.
 costume_or_empty   Costume name of the monster, or empty string if unknown.
 costume_id         Costume ID for the monster.
 costume_id_3       Costume ID of the monster, padded to 3 digits.
+gender             Gender of the monster, represented as a single character.
 ================== =========================================================
 
 

--- a/docs/configuration/filters/raid-filters.rst
+++ b/docs/configuration/filters/raid-filters.rst
@@ -48,6 +48,8 @@ max_raid_lvl      Maximum level of the raid.                       ``5``
 min_cp            Minimum CP of the monster.                       ``0``
 max_cp            Maximum CP of the monster.                       ``100000``
 form_ids          Array of allowed form ids for the monster.       ``[0,"1"]``
+genders           Array of acceptable genders. Options: `"male",   ``["female"]``
+                  "female", "neutral"`
 quick_moves       Accepted quick moves, by id or name.             ``["Vine Whip","Tackle"]``
 charge_moves      Accepted charge moves, by id or name.            ``["Sludge Bomb","Seed Bomb"]``
 current_teams     List of allowed current teams, by id or name.    ``["Instinct","Mystic"]``

--- a/docs/miscellaneous/webhook-standard.md
+++ b/docs/miscellaneous/webhook-standard.md
@@ -197,6 +197,7 @@ webhook event from RocketMap as raids are.
     "message": {
         "gym_id": "gym_id",
         "pokemon_id": 200,
+        "gender": 2,
         "cp": 12345,
         "move_1": 123,
         "move_2": 123,


### PR DESCRIPTION
## Description
<!-- In detail, describe what your PR adds to PokeAlarm -->
Adds gender information to raid event.

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
<!---
 Why is this change required? What problem does it solve?
 If it fixes an open issue, please link to the issue here.
-->
This PR adds support for gender (useful for Burmy, Snorunt etc).

## How Has This Been Tested?
<!---
 Please describe in detail how you tested your changes. Make sure to
 describe what tests you have performed, your testing environment,
 and if you have used this in a production setting. Please add
 screenshots if appropriate.
-->
This has been tested with multiple webhooks and should work.