### PR TITLE
Spawn Verified DTS

### DIFF
--- a/PokeAlarm/Events/MonEvent.py
+++ b/PokeAlarm/Events/MonEvent.py
@@ -9,7 +9,7 @@ from PokeAlarm.Utils import (
     get_move_duration, get_move_energy, get_pokemon_size,
     get_applemaps_link, get_time_as_str, get_seconds_remaining,
     get_base_types, get_dist_as_str, get_weather_emoji,
-    get_type_emoji, get_waze_link)
+    get_verified_emoji, get_type_emoji, get_waze_link)
 from . import BaseEvent
 
 
@@ -34,7 +34,8 @@ class MonEvent(BaseEvent):
             int, data.get('spawn_start'), Unknown.REGULAR)
         self.spawn_end = check_for_none(
             int, data.get('spawn_end'), Unknown.REGULAR)
-        self.spawn_verified = check_for_none(bool, data.get('verified'), False)
+        self.spawn_verified = check_for_none(
+            int, data.get('verified'), Unknown.REGULAR)
 
         # Location
         self.lat = float(data['latitude'])
@@ -159,7 +160,16 @@ class MonEvent(BaseEvent):
             # Spawn Data
             'spawn_start': self.spawn_start,
             'spawn_end': self.spawn_end,
-            'spawn_verified': self.spawn_verified,
+            'spawn_verified':
+                self.spawn_verified > 0 if Unknown.is_not(self.spawn_verified)
+                else Unknown.REGULAR,
+            'verified_emoji': get_verified_emoji(self.spawn_verified),
+            'verified_emoji_or_empty': (
+                '' if self.spawn_verified != 1
+                else get_verified_emoji(self.spawn_verified)),
+            'unverified_emoji_or_empty': (
+                '' if self.spawn_verified != 0
+                else get_verified_emoji(self.spawn_verified)),
 
             # Location
             'lat': self.lat,

--- a/PokeAlarm/Events/MonEvent.py
+++ b/PokeAlarm/Events/MonEvent.py
@@ -9,7 +9,7 @@ from PokeAlarm.Utils import (
     get_move_duration, get_move_energy, get_pokemon_size,
     get_applemaps_link, get_time_as_str, get_seconds_remaining,
     get_base_types, get_dist_as_str, get_weather_emoji,
-    get_verified_emoji, get_type_emoji, get_waze_link)
+    get_spawn_verified_emoji, get_type_emoji, get_waze_link)
 from . import BaseEvent
 
 
@@ -163,13 +163,13 @@ class MonEvent(BaseEvent):
             'spawn_verified':
                 self.spawn_verified > 0 if Unknown.is_not(self.spawn_verified)
                 else Unknown.REGULAR,
-            'verified_emoji': get_verified_emoji(self.spawn_verified),
-            'verified_emoji_or_empty': (
+            'spawn_verified_emoji': get_spawn_verified_emoji(self.spawn_verified),
+            'spawn_verified_emoji_or_empty': (
                 '' if self.spawn_verified != 1
-                else get_verified_emoji(self.spawn_verified)),
-            'unverified_emoji_or_empty': (
+                else get_spawn_verified_emoji(self.spawn_verified)),
+            'spawn_unverified_emoji_or_empty': (
                 '' if self.spawn_verified != 0
-                else get_verified_emoji(self.spawn_verified)),
+                else get_spawn_verified_emoji(self.spawn_verified)),
 
             # Location
             'lat': self.lat,

--- a/PokeAlarm/Utils.py
+++ b/PokeAlarm/Utils.py
@@ -358,6 +358,11 @@ def get_type_emoji(type_id):
         18: u'🌑'
     }.get(type_id, '')
 
+def get_verified_emoji(verified_id):
+    return {
+        0: u'❌',
+        1: u'✅',
+    }.get(verified_id, '❔')
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/PokeAlarm/Utils.py
+++ b/PokeAlarm/Utils.py
@@ -358,11 +358,11 @@ def get_type_emoji(type_id):
         18: u'🌑'
     }.get(type_id, '')
 
-def get_verified_emoji(verified_id):
+def get_spawn_verified_emoji(spawn_verified_id):
     return {
         0: u'❌',
         1: u'✅',
-    }.get(verified_id, '❔')
+    }.get(spawn_verified_id, '❔')
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/configuration/events/monster-events.rst
+++ b/docs/configuration/events/monster-events.rst
@@ -221,11 +221,14 @@ boosted_or_empty         Return `boosted` if monster is boosted, or empty
 Miscellaneous
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-=================== ============================================================
-DTS                 Description
-=================== ============================================================
-encounter_id        The encounter id. Unique per monster spawn.
-spawn_start         Estimated time that the monster spawn starts.
-spawn_end           Estimated time that the monster spawn ends.
-spawn_verified      Whether this spawn times have been verified.
-=================== ============================================================
+=============================== ==============================================================
+DTS                             Description
+=============================== ==============================================================
+encounter_id                    The encounter id. Unique per monster spawn.
+spawn_start                     Estimated time that the monster spawn starts.
+spawn_end                       Estimated time that the monster spawn ends.
+spawn_verified                  Whether this spawn times have been verified.
+spawn_verified_emoji            Return spawn verified emoji for unknown, verified, unverified.
+spawn_verified_emoji_or_empty   Return spawn verified emoji for verified or empty string.
+spawn_unverified_emoji_or_empty Return spawn verified emoji for unverified or empty string.
+=============================== ==============================================================


### PR DESCRIPTION
## Description
This changes the verified data from a simple false/true to a unknown/no/yes.
It also improves the existing dts for this and adds additional emoji dts.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
Prior to this you could not distinguish between no data at all and a unverified one.
And since nearly all my spawns are verified, I rather want to only display dts for unverified.

## How Has This Been Tested?
Tested with latest PokeAlarm and MAD.

## Wiki Update
- [x] This change requires an update to the Wiki.
- [ ] This change does not require an update to the Wiki.