### PR TITLE
Add is_exclusive field support for eggs

### DIFF
--- a/PokeAlarm/Events/EggEvent.py
+++ b/PokeAlarm/Events/EggEvent.py
@@ -52,6 +52,8 @@ class EggEvent(BaseEvent):
             str, data.get('park'), Unknown.REGULAR)
         self.ex_eligible = check_for_none(
             int, data.get('is_ex_raid_eligible'), Unknown.REGULAR)
+        self.is_exclusive = check_for_none(
+            int, data.get('is_exclusive'), Unknown.REGULAR)
 
         # Gym Team (this is only available from cache)
         self.current_team_id = check_for_none(
@@ -124,6 +126,9 @@ class EggEvent(BaseEvent):
                 if Unknown.is_not(self.sponsor_id) else Unknown.REGULAR,
             'ex_eligible':
                 self.ex_eligible > 0 if Unknown.is_not(self.ex_eligible)
+                else Unknown.REGULAR,
+            'is_exclusive':
+                self.is_exclusive > 0 if Unknown.is_not(self.is_exclusive)
                 else Unknown.REGULAR,
             'park': self.park,
             'team_id': self.current_team_id,

--- a/PokeAlarm/Filters/EggFilter.py
+++ b/PokeAlarm/Filters/EggFilter.py
@@ -68,6 +68,12 @@ class EggFilter(BaseFilter):
             limit=BaseFilter.parse_as_type(bool, 'is_ex_eligible', data)
         )
 
+        self.is_exclusive = self.evaluate_attribute(
+            event_attribute='is_exclusive',
+            eval_func=operator.eq,
+            limit=BaseFilter.parse_as_type(bool, 'is_exclusive', data)
+        )
+
         # Team Info
         self.old_team = self.evaluate_attribute(  # f.ctis contains m.cti
             event_attribute='current_team_id', eval_func=operator.contains,

--- a/docs/configuration/events/egg-events.rst
+++ b/docs/configuration/events/egg-events.rst
@@ -35,6 +35,9 @@ egg_lvl           The tier level of the egg.
 gym_name          The name of the gym. *
 gym_description   The description of the gym. *
 gym_image         The url to the image of the gym. *
+ex_eligible       True if the gym currently has an ex tag, False if not.
+is_exclusive      True if the egg is for an ex raid, False if not.
+park              The name of the park the gym is located in.
 team_id           The id of the team currently in control of the gym.
 team_name         The team currently in control of the gym.
 team_leader       The leader of the team currently in control of the gym.

--- a/docs/configuration/filters/egg-filters.rst
+++ b/docs/configuration/filters/egg-filters.rst
@@ -47,6 +47,8 @@ max_egg_lvl        Maximum level of the egg when hatched.           ``5``
 current_teams      List of allowed current teams, by id or name.    ``["Instinct","Mystic"]``
 gym_name_contains  List of regex's required to be in the gym name.  ``["Sponsored","West\\sOak"]``
 gym_name_excludes  List of regex's rejected to be in the gym name.  ``["Sponsored","West\\sOak"]``
+is_ex_eligible     restrict ex_eligible to be zero or not           ``true`` or ``false``
+is_exclusive       restrict is_exclusive to be zero or not          ``true`` or ``false``
 park_contains      List of regex's required to be in the park name. ``["Sponsored","Park\\sName"]``
 sponsored          restrict sponsor_id to be zero or not            ``true`` or ``false``
 ================== ================================================ ================================


### PR DESCRIPTION
## Description
This adds functionality to show if an egg has an exclusive raid or not.
Also has a filter to be able to put those eggs into different alarms.

I also added some missing dts to docs while updating it for this PR.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
MAD can already send this information, so it only makes sense to use it.
I have set up an extra channel for ex eggs after nearly missing one earlier.

## How Has This Been Tested?
Tested with latest PokeAlarm and MAD.

## Wiki Update
- [x] This change requires an update to the Wiki.
- [ ] This change does not require an update to the Wiki.