### PR TITLE
Add option to disable log file

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -17,7 +17,7 @@
 #debug                          # Enable debug logging (default='False)
 #quiet                          # Disable output to stdin/stdout.
 #log-lvl: 3                     # Verbosity of the main logger (default=3)
-#log-file: logs/pokealarm.log   # File path of the main logger (default='logs/pokealam.log')
+#log-file: logs/pokealarm.log   # File path of the main logger (default='logs/pokealam.log'). None to disable logging to file.
 #log-size: 100                  # Maximum size in mb of a log before rollover.
 #log-ct: 5                      # Maximum number of logs to keep.
 

--- a/docs/configuration/server-settings.md
+++ b/docs/configuration/server-settings.md
@@ -161,7 +161,7 @@ You can manually specify a configuration file with either the `-cf` or
 #debug                          # Enable debug logging (default='False)
 #quiet                          # Disable output to stdin/stdout.
 #log-lvl: 3                     # Verbosity of the main logger (default=3)
-#log-file: logs/pokealarm.log   # File path of the main logger (default='logs/pokealam.log')
+#log-file: logs/pokealarm.log   # File path of the main logger (default='logs/pokealam.log'). None to disable logging to file.
 #log-size: 100                  # Maximum size in mb of a log before rollover.
 #log-ct: 5                      # Maximum number of logs to keep.
 

--- a/docs/configuration/server-settings.md
+++ b/docs/configuration/server-settings.md
@@ -73,7 +73,7 @@ optional arguments:
   -ll {1,2,3,4,5}, --log-lvl {1,2,3,4,5}
                         Verbosity of the root logger.
   -lf LOG_FILE, --log-file LOG_FILE
-                        Path of a file to attach to a manager's logger.
+                        Path of a file to attach to a manager's logger. None to disable logging to file.
   -ls LOG_SIZE, --log-size LOG_SIZE
                         Maximum size in mb of a log before rollover.
   -lc LOG_CT, --log-ct LOG_CT

--- a/start_pokealarm.py
+++ b/start_pokealarm.py
@@ -150,7 +150,7 @@ def parse_settings(root_path):
         help='Verbosity of the root logger.')
     parser.add_argument(
         '-lf', '--log-file', type=parse_unicode, default='logs/pokealarm.log',
-        help="Path of a file to attach to a manager's logger.")
+        help="Path of a file to attach to a manager's logger. None to disable logging to file.")
     parser.add_argument(
         '-ls', '--log-size', type=int, default=100,
         help="Maximum size in mb of a log before rollover.")
@@ -258,7 +258,8 @@ def parse_settings(root_path):
     # Setup file logging
     if not os.path.exists(get_path('logs')):
         os.mkdir(get_path('logs'))
-    setup_file_handler(root_logger, args.log_file, args.log_size, args.log_ct)
+    if str(args.log_file).lower() != "none":
+        setup_file_handler(root_logger, args.log_file, args.log_size, args.log_ct)
 
     if args.debug:
         # Set everything to VERY VERBOSE


### PR DESCRIPTION
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->


<!--
 Please make all PRs to the dev branch. The dev branch will be
 periodically pulled into the master branch. This allows time for
 the changes and documentation to be tested before being exposed to
 a wider population.
--->

## Description
<!-- In detail, describe what your PR adds to PokeAlarm -->

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
<!---
 Why is this change required? What problem does it solve?
 If it fixes an open issue, please link to the issue here.
-->
Currently PA does allows logging to file and syslog. Logging to syslog can be disabled via --quiet / -q but there is no option to disable file logging. Running PA as a service and letting syslog / logrotate handle the logs, PA is still logging to the given log file. There is no option to disable that. 

## How Has This Been Tested?
<!---
 Please describe in detail how you tested your changes. Make sure to
 describe what tests you have performed, your testing environment,
 and if you have used this in a production setting. Please add
 screenshots if appropriate.
-->
Tested/Using on a production environment and works as expected. Stopped PA service, edited start_pa.py file + config/config.ini, started PA service and checked if there is still a log file. Changed the option back to another value to make sure logging is only affected if either none or None are specified. Worked like a charm to me.

## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change to https://github.com/RocketMap/PokeAlarmWiki.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [ ] This change requires an update to the Wiki.
- [ ] This change does not require an update to the Wiki.
- [X] The changes for config.ini.example and the read-the-docs / wiki / manual files are included too.