### PR TITLE
Field customization for Discord

### DIFF
--- a/PokeAlarm/Alarms/Discord/DiscordAlarm.py
+++ b/PokeAlarm/Alarms/Discord/DiscordAlarm.py
@@ -178,6 +178,7 @@ class DiscordAlarm(Alarm):
             'title': settings.pop('title', default['title']),
             'url': settings.pop('url', default['url']),
             'body': settings.pop('body', default['body']),
+            'fields': settings.pop('fields', []),
             'map': map if isinstance(map, six.string_types) else
             get_static_map_url(map, self.__static_map_key)
         }
@@ -199,7 +200,8 @@ class DiscordAlarm(Alarm):
                 'title': replace(alert['title'], info),
                 'url': replace(alert['url'], info),
                 'description': replace(alert['body'], info),
-                'thumbnail': {'url': replace(alert['icon_url'], info)}
+                'thumbnail': {'url': replace(alert['icon_url'], info)},
+                'fields': self.replace_fields(alert['fields'], info)
             }]
             if alert['map'] is not None:
                 coords = {
@@ -269,3 +271,14 @@ class DiscordAlarm(Alarm):
             raise requests.exceptions.RequestException(
                 "Response received {}, webhook not accepted.".format(
                     resp.status_code))
+
+    @staticmethod
+    def replace_fields(fields, pkinfo):
+        replaced_fields = []
+        for field in fields:
+            replaced_fields.append({
+                'name': replace(field['name'], pkinfo),
+                'value': replace(field['value'], pkinfo),
+                'inline': field.get('inline', False)
+            })
+        return replaced_fields

--- a/docs/configuration/alarms/discord.rst
+++ b/docs/configuration/alarms/discord.rst
@@ -121,6 +121,7 @@ Parameters      Description                                      Default
 `url`           Link to be added to notification text            ``<gmaps>``
 `body`          Additional text to be added to the message       ``Available until <24h_time>(<time_left>).``
 `content`       Text before the Discord embed
+`fields`        A set of fields. See below for more information.
 =============== ================================================ ===========================================
 
 .. note::
@@ -209,6 +210,53 @@ Example: Alarm Configuration Using Optional Parameters
 .. note::
   \*THESE LINES ARE USED TO OVERRIDE DEFAULT VALUES. IF YOU DO NOT WISH
   TO USE CUSTOM IMAGES, DO NOT ADD THESE LINES TO YOUR ALARMS.JSON.
+
+
+Example: Alarm Configuration Using Fields
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+  The code below is to be inserted into the alarms section of
+  ``alarms.json``. It does not represent the entire ``alarms.json`` file.
+
+.. code-block:: json
+
+  {
+    "discord_alarm":{
+      "active":true,
+      "type":"discord",
+      "webhook_url":"YOUR_WEBHOOK_URL",
+      "startup_message":false,
+      "monsters":{
+          "webhook_url":"YOUR_WEBHOOK_URL_FOR_POKEMON_CHANNEL",
+          "username":"<mon_name>",
+          "icon_url*":"YOUR CUSTOM URL HERE/<mon_id_3>_<form_id_3>.png",
+          "title":"A wild <mon_name> has appeared!",
+          "url":"<gmaps>",
+          "body":"Available until <24h_time> (<time_left>).",
+          "fields": [
+              {
+                  "name": "Detailed Information",
+                  "value": "<mon_name> <cp>...",
+                  "inline": true
+              },
+              {
+                  "name": "More information",
+                  "value": "<iv_0> <form>",
+                  "inline": true
+              },
+              {
+                  "name": "Costume",
+                  "value": "<costume>"
+              }
+          ]
+      }
+    }
+  }
+
+.. note::
+  Fields are always defined with the `name` and `value` keys, with the `inline`
+  key being optional and defaulting to `false`
 
 Mini Map Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Description
Give Discord users further customization to alarms by adding the ability to customize fields

This is mostly a 1:1 of the actual Discord webhook spec, with the exception of the `inline` property.
The inline property is optional and defaults to `false`.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
More customization

## How Has This Been Tested?
Locally, tested all situations I could think of

## Wiki Update
- [x] This change requires an update to the Wiki.
- [ ] This change does not require an update to the Wiki.
(included in PR)