### PR TITLE
Python 3 Slack Alarms Fix

### DIFF
--- a/PokeAlarm/Alarms/Slack/SlackAlarm.py
+++ b/PokeAlarm/Alarms/Slack/SlackAlarm.py
@@ -2,7 +2,7 @@
 import re
 
 # 3rd Party Imports
-from slacker import Slacker
+from slack import WebClient
 
 # Local Imports
 from PokeAlarm.Alarms import Alarm
@@ -130,7 +130,7 @@ class SlackAlarm(Alarm):
 
     # Establish connection with Slack
     def connect(self):
-        self.__client = Slacker(self.__api_key)
+        self.__client = WebClient(self.__api_key)
         self.update_channels()
 
     # Send a message letting the channel know that this alarm started
@@ -213,11 +213,8 @@ class SlackAlarm(Alarm):
     # Get a list of channels from Slack to help
     def update_channels(self):
         self.__channels = {}
-        response = self.__client.channels.list(True).body
-        for channel in response['channels']:
-            self.__channels[channel['name']] = channel['id']
-        response = self.__client.groups.list().body
-        for channel in response['groups']:
+        response = self.__client.conversations_list()
+        for channel in response.data['channels']:
             self.__channels[channel['name']] = channel['id']
         self._log.debug("Detected the following Slack channnels: {}" .format(
             self.__channels))
@@ -246,7 +243,7 @@ class SlackAlarm(Alarm):
         if attachments is not None:
             args['attachments'] = attachments
         try_sending(self._log, self.connect, "Slack",
-                    self.__client.chat.post_message, args)
+                    self.__client.chat_postMessage, args)
 
     # Returns a string s that is in proper channel format
     @staticmethod

--- a/PokeAlarm/Alarms/Slack/__init__.py
+++ b/PokeAlarm/Alarms/Slack/__init__.py
@@ -1,8 +1,8 @@
 try:
-    import slacker  # noqa F401
+    import slack  # noqa F401
 except ImportError:
     from PokeAlarm.Utils import pip_install
 
-    pip_install('slacker', '0.9.24')
+    pip_install('slackclient', '2.9.2')
 
 from .SlackAlarm import SlackAlarm  # noqa 401


### PR DESCRIPTION
## Description
Make Slack alarms with with python 3.7+
Replace slacker API to the official client

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
Slack alarms no longer work since we made the jump to python 3.7

## How Has This Been Tested?
Locally, Windows 10

## Wiki Update
- [ ] This change requires an update to the Wiki.
- [x] This change does not require an update to the Wiki.