### PR TITLE
Force gevent and greenlet versions so new installs with Python 3.7 work

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 configargparse==1.0
 flask==1.1.1
-gevent==1.3.7
+gevent==1.3.4
 pytz==2019.3
 portalocker==1.5.2
 requests==2.22.0
+greenlet==0.4.13


### PR DESCRIPTION
## Description
Fixes issues with new installs using pypi wheels (greenlet and gevent issues specifically)
This will be a temporary fix until we are able to implement gevent's new package structure fully

***This will require PA users to use ONLY Python 3.7***

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
New installs would not work with straight requirements, modification was usually involved

## How Has This Been Tested?
Ubuntu, Python 3.7
Tested with Python 3.8 but can confirm this *will not work*

## Wiki Update
- [ ] This change requires an update to the Wiki.
- [x] This change does not require an update to the Wiki.