### PR TITLE
Fix stat product calculation

### DIFF
--- a/tools/pvp.py
+++ b/tools/pvp.py
@@ -45,8 +45,8 @@ class PVP:
                     multipliers[str(level)]))
                 defense = ((stats[mon]["defense"] + stat_product[1]) * (
                     multipliers[str(level)]))
-                stamina = ((stats[mon]["stamina"] + stat_product[2]) * (
-                    multipliers[str(level)]))
+                stamina = int(((stats[mon]["stamina"] + stat_product[2]) * (
+                    multipliers[str(level)])))
                 product = (attack * defense * stamina)
                 if product > highest["product"]:
                     highest.update({


### PR DESCRIPTION
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->


<!--
 Please make all PRs to the dev branch. The dev branch will be
 periodically pulled into the master branch. This allows time for
 the changes and documentation to be tested before being exposed to
 a wider population.
--->

## Description
It has been brought to my attention that using the pvp.py tool yields wrong stat product numbers. Upon inspection, I found this was because the rounding of the stamina value had been removed during a "code cleanup" 😉 

This PR fixes that issue.

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
Simple bug fix.

## How Has This Been Tested?
Verified the calculations to match trusted sources again (http://pogostat.com/, poraclePvpHelper plugin 😉 )

## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change to https://github.com/RocketMap/PokeAlarmWiki.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [ ] This change requires an update to the Wiki.
- [x] This change does not require an update to the Wiki.