### PR TITLE
Cache geocoding results in manager object cache

### DIFF
--- a/PokeAlarm/Cache/FileCache.py
+++ b/PokeAlarm/Cache/FileCache.py
@@ -45,6 +45,8 @@ class FileCache(Cache):
                 self._day_or_night_id = data.get('day_or_night_id', {})
                 self._quest_reward = data.get('quest_reward', {})
                 self._quest_task = data.get('quest_task', {})
+                self._loc_geocode = data.get('loc_geocode', {})
+                self._loc_rev_geocode = data.get('loc_rev_geocode', {})
 
                 self._log.debug("Cache loaded successfully.")
         except Exception as e:
@@ -70,7 +72,9 @@ class FileCache(Cache):
             'severity_id': self._severity_id,
             'day_or_night_id': self._day_or_night_id,
             'quest_reward': self._quest_reward,
-            'quest_task': self._quest_task
+            'quest_task': self._quest_task,
+            'loc_geocode': self._loc_geocode,
+            'loc_rev_geocode': self._loc_rev_geocode
         }
         try:
             # Write to temporary file and then rename

--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -30,7 +30,8 @@ Rule = namedtuple('Rule', ['filter_names', 'alarm_names'])
 
 class Manager(object):
     def __init__(self, name, google_key, locale, units, timezone, time_limit,
-                 max_attempts, location, cache_type, geofence_file, debug):
+                 max_attempts, location, cache_type, geofence_file, debug,
+                 gmaps_cache_fuzz):
         # Set the name of the Manager
         self.name = str(name).lower()
         self._log = self._create_logger(self.name)
@@ -38,12 +39,16 @@ class Manager(object):
 
         self.__debug = debug
 
+        # Create cache
+        self.__cache = cache_factory(self, cache_type)
+
         # Get the Google Maps AP# TODO: Improve error checking
         self._google_key = None
         self._gmaps_service = None
         if str(google_key).lower() != 'none':
             self._google_key = google_key
-            self._gmaps_service = GMaps(google_key)
+            self._gmaps_service = GMaps(google_key, gmaps_cache_fuzz,
+                                        self.__cache)
         self._gmaps_reverse_geocode = False
         self._gmaps_distance_matrix = set()
 
@@ -61,9 +66,6 @@ class Manager(object):
             self._log.warning(
                 "NO LOCATION SET - this may cause issues "
                 "with distance related DTS.")
-
-        # Create cache
-        self.__cache = cache_factory(self, cache_type)
 
         # Load and Setup the Pokemon Filters
         self._mons_enabled, self._mon_filters = False, OrderedDict()

--- a/docs/miscellaneous/location-services.rst
+++ b/docs/miscellaneous/location-services.rst
@@ -193,3 +193,10 @@ in PokeAlarm may not function correctly. If you find that you are exceeding
 the free daily 2,500 API calls, you may either switch to another valid Google
 Maps API key for the day or sign up for a Google Maps API Premium plan. For
 pricing information, visit the `Google Maps API Pricing and Plans page <https://developers.google.com/maps/pricing-and-plans/#details>`_.
+
+
+Caching
+-------------------------------------
+
+Geocoding results are cached for one month using the configured :doc:`object-caching` method.
+Distance matrix results are never cached.

--- a/docs/miscellaneous/object-caching.rst
+++ b/docs/miscellaneous/object-caching.rst
@@ -21,8 +21,8 @@ Introduction
 -------------------------------------
 
 PokeAlarm uses `Cache` objects to store information that is not present on
-runtime. The cached objects store information such as ``gym-info`` and other
-dynamic objects sent into PokeAlarm via webhook. Cached data is used for
+runtime. The cached objects store information such as :doc:`location-service` results,
+``gym-info`` and other dynamic objects sent into PokeAlarm via webhook. Cached data is used for
 internal calculations as well as to provide details for :doc:`../configuration/events/index`
 in :doc:`../configuration/alarms/index`.
 

--- a/start_pokealarm.py
+++ b/start_pokealarm.py
@@ -216,6 +216,9 @@ def parse_settings(root_path):
         '-k', '--gmaps-key', action='append',
         default=[None], help='Specify a Google API Key to use.')
     parser.add_argument(
+        '--gmaps-cache-fuzz', type=int, action='append',
+        default=[0], help='Max. fuzz in days to add to caching time.')
+    parser.add_argument(
         '--gmaps-rev-geocode', type=parse_boolean, action='append',
         default=[None], help='Enable Walking Distance Matrix DTS.')
     parser.add_argument(
@@ -293,7 +296,7 @@ def parse_settings(root_path):
                 args.timezone, args.gmaps_rev_geocode, args.gmaps_dm_walk,
                 args.gmaps_dm_bike, args.gmaps_dm_drive,
                 args.gmaps_dm_transit, args.mgr_log_lvl, args.mgr_log_size,
-                args.mgr_log_file]:
+                args.mgr_log_file, args.gmaps_cache_fuzz]:
         if len(arg) > 1:  # Remove defaults from the list
             arg.pop(0)
         size = len(arg)
@@ -332,6 +335,8 @@ def parse_settings(root_path):
             name=args.manager_name[m_ct],
             google_key=get_from_list(
                 args.gmaps_key, m_ct, args.gmaps_key[0]),
+            gmaps_cache_fuzz=get_from_list(
+                args.gmaps_cache_fuzz, m_ct, args.gmaps_cache_fuzz[0]),
             locale=get_from_list(args.locale, m_ct, args.locale[0]),
             units=get_from_list(args.units, m_ct, args.units[0]),
             timezone=get_from_list(args.timezone, m_ct, args.timezone[0]),


### PR DESCRIPTION
## Description
The move of the cache makes restarts without losing
cached geocoding results possible; if a disk cache is used.
Previously the cache was always in-memory only.

Cached results expire after one month now.

The new 'gmaps-cache-fuzz' option can be used in the config
to flatten re-lookup spikes that could happen if a lot of
requests were made at the same day, i.e. during an event.
It randomly increases cache expiration to up to the configured
value in days (defaults to 0).

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
Makes it possible to restart without losing gmaps results.

## How Has This Been Tested?
The patch is running in production for two weeks and shows the
expected results with several restarts in the meantime.

## Wiki Update
The wiki seems to be dead, so either remove this section or update the URL.