### PR TITLE
RDM Monster Webhooks

### DIFF
--- a/PokeAlarm/Events/MonEvent.py
+++ b/PokeAlarm/Events/MonEvent.py
@@ -37,7 +37,11 @@ class MonEvent(BaseEvent):
         self.spawn_end = check_for_none(
             int, data.get('spawn_end'), Unknown.REGULAR)
         self.spawn_verified = check_for_none(
-            int, data.get('verified'), Unknown.REGULAR)
+            int,
+            data.get('verified', data.get('disappear_time_verified')),
+            Unknown.REGULAR)
+        self.spawnpoint_id = check_for_none(
+            str, data.get('spawnpoint_id'), Unknown.REGULAR)
 
         # Location
         self.lat = float(data['latitude'])
@@ -102,11 +106,17 @@ class MonEvent(BaseEvent):
 
         # Catch Probs
         self.base_catch = check_for_none(
-            float, data.get('base_catch'), Unknown.TINY)
+            float,
+            data.get('base_catch', data.get('capture_1')),
+            Unknown.TINY)
         self.great_catch = check_for_none(
-            float, data.get('great_catch'), Unknown.TINY)
+            float,
+            data.get('great_catch', data.get('capture_2')),
+            Unknown.TINY)
         self.ultra_catch = check_for_none(
-            float, data.get('ultra_catch'), Unknown.TINY)
+            float,
+            data.get('ultra_catch', data.get('capture_3')),
+            Unknown.TINY)
 
         # Attack Rating
         self.atk_grade = check_for_none(
@@ -187,6 +197,7 @@ class MonEvent(BaseEvent):
             'spawn_unverified_emoji_or_empty': (
                 '' if self.spawn_verified != 0
                 else get_spawn_verified_emoji(self.spawn_verified)),
+            'spawnpoint_id': self.spawnpoint_id,
 
             # Location
             'lat': self.lat,

--- a/docs/configuration/events/monster-events.rst
+++ b/docs/configuration/events/monster-events.rst
@@ -259,6 +259,7 @@ Miscellaneous
 DTS                             Description
 =============================== ==============================================================
 encounter_id                    The encounter id. Unique per monster spawn.
+spawnpoint_id                   Return the spawnpoint ID that the monster spawned on.
 spawn_start                     Estimated time that the monster spawn starts.
 spawn_end                       Estimated time that the monster spawn ends.
 spawn_verified                  Whether this spawn times have been verified.


### PR DESCRIPTION
## Description
Add keys for RDM in catch rates, and verified
Add `spawnpoint_id` DTS since it's sent by both scanners

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
Fixes stuff for some RDM webhooks
Adds new stuff for everyone

## How Has This Been Tested?
Not at all, will have someone else test

## Wiki Update
- [x] This change requires an update to the Wiki.
- [ ] This change does not require an update to the Wiki.

Docs update included