### PR TITLE
Add boosted weather filters

### DIFF
--- a/PokeAlarm/Filters/MonFilter.py
+++ b/PokeAlarm/Filters/MonFilter.py
@@ -171,6 +171,16 @@ class MonFilter(BaseFilter):
         self.weather_ids = self.evaluate_attribute(
             event_attribute='weather_id', eval_func=operator.contains,
             limit=BaseFilter.parse_as_set(get_weather_id, 'weather', data))
+        self.boosted_weather_ids = self.evaluate_attribute(
+            event_attribute='boosted_weather_id', eval_func=operator.contains,
+            limit=BaseFilter.parse_as_set(
+                get_weather_id, 'boosted_weather', data))
+        self.boosted_weather = self.evaluate_attribute(
+            event_attribute='boosted_weather_id',
+            eval_func=lambda d, v:
+            (d is True and v != 0 and v is not None)
+            or (d is False and (v == 0 or v is None)),
+            limit=BaseFilter.parse_as_type(bool, 'is_boosted_weather', data))
 
         # Rarity
         self.rarity_ids = self.evaluate_attribute(  #

--- a/PokeAlarm/Filters/MonFilter.py
+++ b/PokeAlarm/Filters/MonFilter.py
@@ -4,7 +4,7 @@ import operator
 # Local Imports
 from . import BaseFilter
 from PokeAlarm.Utilities import MonUtils as MonUtils
-from PokeAlarm.Utils import get_weather_id
+from PokeAlarm.Utils import get_weather_id, weather_id_is_boosted
 
 
 class MonFilter(BaseFilter):
@@ -177,9 +177,7 @@ class MonFilter(BaseFilter):
                 get_weather_id, 'boosted_weather', data))
         self.boosted_weather = self.evaluate_attribute(
             event_attribute='boosted_weather_id',
-            eval_func=lambda d, v:
-            (d is True and v != 0 and v is not None)
-            or (d is False and (v == 0 or v is None)),
+            eval_func=weather_id_is_boosted,
             limit=BaseFilter.parse_as_type(bool, 'is_boosted_weather', data))
 
         # Rarity

--- a/PokeAlarm/Utils.py
+++ b/PokeAlarm/Utils.py
@@ -366,6 +366,14 @@ def is_weather_boosted(pokemon_id, weather_id):
     return types[0] in boosted_types or types[1] in boosted_types
 
 
+def weather_id_is_boosted(desired_status, weather_id):
+    if desired_status is True and weather_id != 0 and weather_id is not None:
+        return True
+    if desired_status is False and (weather_id == 0 or weather_id is None):
+        return True
+    return False
+
+
 def get_weather_emoji(weather_id):
     return {
         1: '☀️',

--- a/docs/configuration/filters/monster-filters.rst
+++ b/docs/configuration/filters/monster-filters.rst
@@ -112,19 +112,21 @@ min_cp_ultra    Minimum resulting ultra league CP for the mon                   
 Miscellaneous
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-=============== ====================================================== ==============================
-Parameter       Description                                            Example
-=============== ====================================================== ==============================
-min_dist        Min distance of event from set location in miles       ``0.0`` *
-                or meters (depending on settings).
-max_dist        Max distance of event from set location in miles       ``1000.0`` *
-                or meters (depending on settings).
-min_time_left   Minimum time (in seconds) until monster despawns.      ``1000``
-max_time_left   Maximum time (in seconds) until monster despawns.      ``2400``
-weather         Accepted weathers, by id or name.                      ``["Clear",2]``
-geofences       See :ref:`geofences_filters` page on 'Geofences'       ``["geofence1","geofence2"]``
-custom_dts      See :ref:`custom_dts_filters` page on 'Custom DTS'     ``{"dts1":"substitution"}``
-is_missing_info See :ref:`missing_info_filters` page on 'Missing Info' ``true`` or ``false``
-=============== ====================================================== ==============================
+================== ====================================================== ==============================
+Parameter          Description                                            Example
+================== ====================================================== ==============================
+min_dist           Min distance of event from set location in miles       ``0.0`` *
+                   or meters (depending on settings).
+max_dist           Max distance of event from set location in miles       ``1000.0`` *
+                   or meters (depending on settings).
+min_time_left      Minimum time (in seconds) until monster despawns.      ``1000``
+max_time_left      Maximum time (in seconds) until monster despawns.      ``2400``
+weather            Accepted weather conditions, by id or name.            ``["Clear",2]``
+boosted_weather    Accepted boosted weather condition, by id or name.     ``["Clear",2]``
+is_boosted_weather Accepts or denies based off boosted weather condition. ``true``
+geofences          See :ref:`geofences_filters` page on 'Geofences'       ``["geofence1","geofence2"]``
+custom_dts         See :ref:`custom_dts_filters` page on 'Custom DTS'     ``{"dts1":"substitution"}``
+is_missing_info    See :ref:`missing_info_filters` page on 'Missing Info' ``true`` or ``false``
+================== ====================================================== ==============================
 
 + Floats can use ``"inf"`` to represent infinity

--- a/tests/filters/test_monster_filter.py
+++ b/tests/filters/test_monster_filter.py
@@ -274,6 +274,20 @@ class TestMonsterFilter(unittest.TestCase):
         self.pass_vals = [1, 5]
         self.fail_vals = [0, 2, 8]
 
+    @generic_filter_test
+    def test_boosted_weather(self):
+        self.filt = {'boosted_weather': [1, 'windy']}
+        self.event_key = 'boosted_weather'
+        self.pass_vals = [1, 5]
+        self.fail_vals = [0, 2, 8]
+
+    @generic_filter_test
+    def test_is_boosted_weather(self):
+        self.filt = {'is_boosted_weather': True}
+        self.event_key = 'boosted_weather'
+        self.pass_vals = [1, 2, 5]
+        self.fail_vals = [0]
+
     def test_time_left(self):
         # Create the filter
         filt = self.gen_filter(


### PR DESCRIPTION
## Description
Adds boosted weather filters
`is_boosted_weather` is boolean
`boosted_weather` accepts an array of weather conditions

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
People want a way to filter by boosted condition

## How Has This Been Tested?
Locally, Windows 10

## Wiki Update
- [x] This change requires an update to the Wiki.
- [ ] This change does not require an update to the Wiki.

Wiki update included