### PR TITLE
Fix DTS for <great_url> and <ultra_url>

### DIFF
--- a/PokeAlarm/Events/MonEvent.py
+++ b/PokeAlarm/Events/MonEvent.py
@@ -262,8 +262,8 @@ class MonEvent(BaseEvent):
                     'att_iv': self.atk_iv,
                     'def_iv': self.def_iv,
                     'hp_iv': self.sta_iv,
-                    'min_iv': '0',
-                    'include-best-buddy': 'false'
+                    'min-iv': '0',
+                    'levelCap': '50'
                 }),
             'great_pvpoke':
                 'https://pvpoke.com/rankings/all/1500/overall/{}{}/'.format(
@@ -292,8 +292,8 @@ class MonEvent(BaseEvent):
                     'att_iv': self.atk_iv,
                     'def_iv': self.def_iv,
                     'hp_iv': self.sta_iv,
-                    'min_iv': '0',
-                    'include-best-buddy': 'false'
+                    'min-iv': '0',
+                    'levelCap': '50'
                 }),
             'ultra_pvpoke':
                 'https://pvpoke.com/rankings/all/2500/overall/{}{}/'.format(


### PR DESCRIPTION
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->


<!--
 Please make all PRs to the dev branch. The dev branch will be
 periodically pulled into the master branch. This allows time for
 the changes and documentation to be tested before being exposed to
 a wider population.
--->

## Description
<!-- In detail, describe what your PR adds to PokeAlarm -->
The current states of `<great_url>` and `<ultra_url>` produces a link to stadiumgaming.gg with incorrect value for "Minimal IV" and a non existing for "Use of Best Buddy". This is likely the old usage from the preLvl 50 times.

This fix now uses the correct parameters for "Minimal IV" and "Level Cap".

Old URL:
```
https://www.stadiumgaming.gg/rank-checker?pokemon=Medicham&league=1500&att_iv=15&def_iv=15&hp_iv=15&min_iv=0&include-best-buddy=false
```
![OLD](https://user-images.githubusercontent.com/31369952/112759870-3bebca00-8ff5-11eb-8829-6e4e1600607e.png)

New URL:
```
https://www.stadiumgaming.gg/rank-checker?pokemon=Medicham&league=1500&att_iv=15&def_iv=15&hp_iv=15&min-iv=0&levelCap=50
```
![NEW](https://user-images.githubusercontent.com/31369952/112759901-5f167980-8ff5-11eb-98ac-25c0d7436d66.png)


## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
<!---
 Why is this change required? What problem does it solve?
 If it fixes an open issue, please link to the issue here.
-->
The current state produces an URL that selects Level 40 as the max level for Pokémon. This fixes that to Level 50

## How Has This Been Tested?
<!---
 Please describe in detail how you tested your changes. Make sure to
 describe what tests you have performed, your testing environment,
 and if you have used this in a production setting. Please add
 screenshots if appropriate.
-->
I've just update my local copy of PA and waited for an event that produced an output to Discord and clicked on the link there.

## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change to https://github.com/RocketMap/PokeAlarmWiki.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [ ] This change requires an update to the Wiki.
- [x] This change does not require an update to the Wiki.