### PR TITLE
Display monsters (ditto)

### DIFF
--- a/PokeAlarm/Alarms/Discord/DiscordAlarm.py
+++ b/PokeAlarm/Alarms/Discord/DiscordAlarm.py
@@ -28,6 +28,10 @@ class DiscordAlarm(Alarm):
                 "regular/monsters/<mon_id_3>_<form_id_3>.png"),
             'avatar_url': get_image_url(
                 "regular/monsters/<mon_id_3>_<form_id_3>.png"),
+            'display_icon_url': get_image_url(
+                "regular/monsters/<display_mon_id_3>_<display_form_id_3>.png"),
+            'display_avatar_url': get_image_url(
+                "regular/monsters/<display_mon_id_3>_<display_form_id_3>.png"),
             'title': "A wild <mon_name> has appeared!",
             'url': "<gmaps>",
             'body': "Available until <24h_time> (<time_left>)."
@@ -166,14 +170,23 @@ class DiscordAlarm(Alarm):
     # Set the appropriate settings for each alert
     def create_alert_settings(self, settings, default):
         map = settings.pop('map', self.__map)
+        use_display_icon = settings.pop('use_display_icon', False)
+        use_display_avatar = settings.pop('use_display_avatar', False)
+
         alert = {
             'webhook_url': settings.pop('webhook_url', self.__webhook_url),
             'username': settings.pop('username', default['username']),
-            'avatar_url': settings.pop('avatar_url', default['avatar_url']),
+            'avatar_url': settings.pop(
+                'avatar_url',
+                default['display_avatar_url']
+                if use_display_avatar else default['avatar_url']),
             'disable_embed': parse_boolean(
                 settings.pop('disable_embed', self.__disable_embed)),
             'content': settings.pop('content', default['content']),
-            'icon_url': settings.pop('icon_url', default['icon_url']),
+            'icon_url': settings.pop(
+                'icon_url',
+                default['display_icon_url']
+                if use_display_icon else default['icon_url']),
             'title': settings.pop('title', default['title']),
             'url': settings.pop('url', default['url']),
             'body': settings.pop('body', default['body']),

--- a/PokeAlarm/Alarms/FacebookPage/FacebookPageAlarm.py
+++ b/PokeAlarm/Alarms/FacebookPage/FacebookPageAlarm.py
@@ -27,6 +27,8 @@ class FacebookPageAlarm(Alarm):
             'message': "A wild <mon_name> has appeared!",
             'image': get_image_url(
                 "regular/monsters/<mon_id_3>_<form_id_3>.png"),
+            'display_image': get_image_url(
+                "regular/monsters/<display_mon_id_3>_<display_form_id_3>.png"),
             'link': "<gmaps>",
             'name': "<mon_name>",
             'description': "Available until <24h_time> (<time_left>).",
@@ -148,12 +150,14 @@ class FacebookPageAlarm(Alarm):
 
     # Set the appropriate settings for each alert
     def create_alert_settings(self, settings, default):
+        use_display_image = settings.pop('use_display_image', False)
         alert = {
             'message': settings.pop('message', default['message']),
             'link': settings.pop('link', default['link']),
             'caption': settings.pop('caption', default['caption']),
             'description': settings.pop('description', default['description']),
-            'image': settings.pop('image', default['image']),
+            'image': settings.pop('image', default['display_image']
+                                  if use_display_image else default['image']),
             'name': settings.pop('name', default['name'])
         }
         reject_leftover_parameters(

--- a/PokeAlarm/Alarms/Slack/SlackAlarm.py
+++ b/PokeAlarm/Alarms/Slack/SlackAlarm.py
@@ -27,6 +27,8 @@ class SlackAlarm(Alarm):
             'username': "<mon_name>",
             'icon_url': get_image_url(
                 "regular/monsters/<mon_id_3>_<form_id_3>.png"),
+            'display_icon_url': get_image_url(
+                "regular/monsters/<display_mon_id_3>_<display_form_id_3>.png"),
             'title': "A wild <mon_name> has appeared!",
             'url': "<gmaps>",
             'body': "Available until <24h_time> (<time_left>)."
@@ -143,10 +145,13 @@ class SlackAlarm(Alarm):
     # Set the appropriate settings for each alert
     def create_alert_settings(self, settings, default):
         map = settings.pop('map', self.__map)
+        use_display_icon = settings.pop('use_display_icon', False)
         alert = {
             'channel': settings.pop('channel', self.__default_channel),
             'username': settings.pop('username', default['username']),
-            'icon_url': settings.pop('icon_url', default['icon_url']),
+            'icon_url': settings.pop('icon_url', default['display_icon_url']
+                                     if use_display_icon
+                                     else default['icon_url']),
             'title': settings.pop('title', default['title']),
             'url': settings.pop('url', default['url']),
             'body': settings.pop('body', default['body']),

--- a/PokeAlarm/Alarms/Telegram/TelegramAlarm.py
+++ b/PokeAlarm/Alarms/Telegram/TelegramAlarm.py
@@ -33,7 +33,10 @@ class TelegramAlarm(Alarm):
             'message': "*A wild <mon_name> has appeared!*\n"
                        "Available until <24h_time> (<time_left>).",
             'sticker_url': get_image_url(
-                "telegram/monsters/<mon_id_3>_<form_id_3>.webp")
+                "telegram/monsters/<mon_id_3>_<form_id_3>.webp"),
+            'display_sticker_url': get_image_url(
+                "telegram/monsters/<display_mon_id_3>_<display_form_id_3>.webp"
+            )
         },
         'stops': {
             'message': "*Someone has placed a lure on a Pokestop!*\n"
@@ -205,7 +208,9 @@ class TelegramAlarm(Alarm):
         message = replace(alert.message, dts)
         lat, lng = dts['lat'], dts['lng']
         max_attempts = alert.max_attempts
-        sticker_url = replace(alert.sticker_url, dts)
+        sticker_url = replace(alert.display_sticker_url, dts) \
+            if alert.use_display_sticker is False\
+            else replace(alert.sticker_url, dts)
         self._log.debug(sticker_url)
         # Send Sticker
         if alert.sticker and sticker_url is not None:

--- a/PokeAlarm/Alarms/Telegram/TelegramAlarm.py
+++ b/PokeAlarm/Alarms/Telegram/TelegramAlarm.py
@@ -209,7 +209,7 @@ class TelegramAlarm(Alarm):
         lat, lng = dts['lat'], dts['lng']
         max_attempts = alert.max_attempts
         sticker_url = replace(alert.display_sticker_url, dts) \
-            if alert.use_display_sticker is False\
+            if alert.use_display_sticker is True\
             else replace(alert.sticker_url, dts)
         self._log.debug(sticker_url)
         # Send Sticker

--- a/PokeAlarm/Events/MonEvent.py
+++ b/PokeAlarm/Events/MonEvent.py
@@ -145,6 +145,16 @@ class MonEvent(BaseEvent):
         # Rarity
         self.rarity_id = check_for_none(int, data.get('rarity'), Unknown.TINY)
 
+        # Display Monster Information (Generally the real monster is ditto)
+        self.display_monster_id = check_for_none(
+            int, data.get('display_pokemon_id'), 0)
+        self.display_form_id = check_for_none(
+            int, data.get('display_form'), 0)
+        self.display_costume_id = check_for_none(
+            int, data.get('display_costume'), 0)
+        self.display_gender = MonUtils.get_gender_sym(
+            check_for_none(int, data.get('display_gender'), Unknown.TINY))
+
         # Correct this later
         self.name = self.monster_id
         self.geofence = Unknown.REGULAR
@@ -381,6 +391,24 @@ class MonEvent(BaseEvent):
                 "{:.2f}".format(self.weight) if Unknown.is_not(self.weight)
                 else Unknown.SMALL),
             'size': locale.get_size_name(self.size_id),
+
+            # Display Information (Usually when the actual mon is a ditto)
+            'display_mon_id': self.display_monster_id,
+            'display_mon_name': locale.get_pokemon_name(
+                self.display_monster_id),
+            'display_mon_id_3': "{:03}".format(self.display_monster_id),
+            'display_mon_id_2': "{:02}".format(self.display_monster_id),
+            'display_costume_id': self.display_costume_id,
+            'display_costume_id_2': "{:02d}".format(self.display_costume_id),
+            'display_costume_id_3': "{:03d}".format(self.display_costume_id),
+            'display_costume': locale.get_costume_name(
+                self.display_monster_id, self.display_costume_id),
+            'display_form_id': self.display_form_id,
+            'display_form': locale.get_form_name(
+                self.display_monster_id, self.display_form_id),
+            'display_form_id_3': "{:03d}".format(self.display_form_id),
+            'display_form_id_2': "{:02d}".format(self.display_form_id),
+            'display_gender': self.display_gender,
 
             # Misc
             'atk_grade': (


### PR DESCRIPTION
## Description
Add new MAD-based "display" monster information
tl;dr, the monster that gets shown in the overworld when it's a ditto

Note: these keys are subject to change since nothing has really been approved

It adds some nice DTS

`display_mon_id` - the ID of the monster being displayed
`display_mon_name`  - the name of the displayed monster (based on locale)
`display_mon_id_3` - a pre-padded zero 3-digit number representing the displayed monster ID
`display_mon_id_2` - a pre-padded zero 2-digit number representing the displayed monster ID
`display_costume_id` - the ID of the costume the displayed monster has
`display_costume_id_2` - a pre-padded zero 2-digit number representing the displayed monster's costume ID
`display_costume_id_3` - a pre-padded zero 3-digit number representing the displayed monster's costume ID
`display_costume` - the full name of the displayed monster's costume (based on locale)
`display_form_id` - the ID of the displayed monster's form
`display_form` - the name of the displayed monster's form (based on locale)
`display_form_id_3` - a pre-padded zero 3-digit number representing the displayed monster's form ID
`display_form_id_2` - a pre-padded zero 2-digit number representing the displayed monster's form ID
`display_gender` - the greek symbol representing the displayed monster's gender

Since we need a way to use the "display" monster image for the default image provider, I added some alarm keys for monsters too

Discord: `use_display_icon` and `use_display_avatar`
FB: `use_display_image`
Slack: `use_display_icon`
Telegram: `use_display_sticker`

!! this gets overridden if the key exists for a custom image provider !!

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
Some people want to know which monster to click on

## How Has This Been Tested?
win 10, python 3.8, discord only

## Wiki Update
- [x] This change requires an update to the Wiki.
- [ ] This change does not require an update to the Wiki.

Wiki changes to come later based on team discussion, see above for full listing of new keys