### PR TITLE
Discord footer timestamps

### DIFF
--- a/PokeAlarm/Alarms/Discord/DiscordAlarm.py
+++ b/PokeAlarm/Alarms/Discord/DiscordAlarm.py
@@ -126,8 +126,7 @@ class DiscordAlarm(Alarm):
         self.__avatar_url = settings.pop('avatar_url', "")
         self.__map = settings.pop('map', {})
         self.__static_map_key = static_map_key
-        self.__timestamp = parse_boolean(
-            settings.pop('footer_timestamp', "False"))
+        self.__timestamp = settings.pop('footer_timestamp', False)
 
         # Set Alert Parameters
         self.__monsters = self.create_alert_settings(

--- a/PokeAlarm/Events/EggEvent.py
+++ b/PokeAlarm/Events/EggEvent.py
@@ -83,6 +83,8 @@ class EggEvent(BaseEvent):
             'hatch_time_raw_hours': hatch_time[6],
             'hatch_time_raw_minutes': hatch_time[7],
             'hatch_time_raw_seconds': hatch_time[8],
+            'hatch_time_utc':
+                self.hatch_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
 
             # Raid Time Remaining
             'raid_time_left': raid_end_time[0],
@@ -94,6 +96,7 @@ class EggEvent(BaseEvent):
             'raid_time_raw_hours': raid_end_time[6],
             'raid_time_raw_minutes': raid_end_time[7],
             'raid_time_raw_seconds': raid_end_time[8],
+            'raid_end_utc': self.raid_end,
 
             # Location
             'lat': self.lat,

--- a/PokeAlarm/Events/EggEvent.py
+++ b/PokeAlarm/Events/EggEvent.py
@@ -97,6 +97,7 @@ class EggEvent(BaseEvent):
             'raid_time_raw_minutes': raid_end_time[7],
             'raid_time_raw_seconds': raid_end_time[8],
             'raid_end_utc': self.raid_end,
+            'current_timestamp_utc': datetime.utcnow(),
 
             # Location
             'lat': self.lat,

--- a/PokeAlarm/Events/GruntEvent.py
+++ b/PokeAlarm/Events/GruntEvent.py
@@ -89,6 +89,7 @@ class GruntEvent(BaseEvent):
             'time_left_raw_minutes': time[7],
             'time_left_raw_seconds': time[8],
             'expiration_utc': self.expiration,
+            'current_timestamp_utc': datetime.utcnow(),
 
             # Location
             'lat': self.lat,

--- a/PokeAlarm/Events/GruntEvent.py
+++ b/PokeAlarm/Events/GruntEvent.py
@@ -88,6 +88,7 @@ class GruntEvent(BaseEvent):
             'time_left_raw_hours': time[6],
             'time_left_raw_minutes': time[7],
             'time_left_raw_seconds': time[8],
+            'expiration_utc': self.expiration,
 
             # Location
             'lat': self.lat,

--- a/PokeAlarm/Events/GymEvent.py
+++ b/PokeAlarm/Events/GymEvent.py
@@ -1,4 +1,5 @@
 # Standard Library Imports
+from datetime import datetime
 # 3rd Party Imports
 # Local Imports
 from PokeAlarm.Utils import get_gmaps_link, get_applemaps_link, \
@@ -97,5 +98,7 @@ class GymEvent(BaseEvent):
             # Guards
             'slots_available': self.slots_available,
             'guard_count': self.guard_count,
+
+            'current_timestamp_utc': datetime.utcnow(),
         })
         return dts

--- a/PokeAlarm/Events/MonEvent.py
+++ b/PokeAlarm/Events/MonEvent.py
@@ -183,6 +183,7 @@ class MonEvent(BaseEvent):
             'time_left_raw_minutes': time[7],
             'time_left_raw_seconds': time[8],
             'disappear_time_utc': self.disappear_time,
+            'current_timestamp_utc': datetime.utcnow(),
 
             # Spawn Data
             'spawn_start': self.spawn_start,

--- a/PokeAlarm/Events/MonEvent.py
+++ b/PokeAlarm/Events/MonEvent.py
@@ -182,6 +182,7 @@ class MonEvent(BaseEvent):
             'time_left_raw_hours': time[6],
             'time_left_raw_minutes': time[7],
             'time_left_raw_seconds': time[8],
+            'disappear_time_utc': self.disappear_time,
 
             # Spawn Data
             'spawn_start': self.spawn_start,

--- a/PokeAlarm/Events/QuestEvent.py
+++ b/PokeAlarm/Events/QuestEvent.py
@@ -148,6 +148,8 @@ class QuestEvent(BaseEvent):
             'raw_item_type': self.item_type,
             'item': get_item_id(self.item_id),
             'item_id': self.item_id,
-            'item_id_4': "{:04d}".format(self.item_id)
+            'item_id_4': "{:04d}".format(self.item_id),
+
+            'current_timestamp_utc': datetime.utcnow()
         })
         return dts

--- a/PokeAlarm/Events/RaidEvent.py
+++ b/PokeAlarm/Events/RaidEvent.py
@@ -140,6 +140,8 @@ class RaidEvent(BaseEvent):
             'raid_time_raw_minutes': raid_end_time[7],
             'raid_time_raw_seconds': raid_end_time[8],
 
+            'raid_end_utc': self.raid_end,
+
             # Type
             'type1': type1,
             'type1_or_empty': Unknown.or_empty(type1),

--- a/PokeAlarm/Events/RaidEvent.py
+++ b/PokeAlarm/Events/RaidEvent.py
@@ -141,6 +141,7 @@ class RaidEvent(BaseEvent):
             'raid_time_raw_seconds': raid_end_time[8],
 
             'raid_end_utc': self.raid_end,
+            'current_timestamp_utc': datetime.utcnow(),
 
             # Type
             'type1': type1,

--- a/PokeAlarm/Events/StopEvent.py
+++ b/PokeAlarm/Events/StopEvent.py
@@ -74,6 +74,7 @@ class StopEvent(BaseEvent):
             'time_left_raw_minutes': time[7],
             'time_left_raw_seconds': time[8],
             'expiration_utc': self.expiration,
+            'current_timestamp_utc': datetime.utcnow(),
 
             # Location
             'lat': self.lat,

--- a/PokeAlarm/Events/StopEvent.py
+++ b/PokeAlarm/Events/StopEvent.py
@@ -73,6 +73,7 @@ class StopEvent(BaseEvent):
             'time_left_raw_hours': time[6],
             'time_left_raw_minutes': time[7],
             'time_left_raw_seconds': time[8],
+            'expiration_utc': self.expiration,
 
             # Location
             'lat': self.lat,

--- a/PokeAlarm/Events/WeatherEvent.py
+++ b/PokeAlarm/Events/WeatherEvent.py
@@ -1,4 +1,5 @@
 # Standard Library Imports
+from datetime import datetime
 # 3rd Party Imports
 # Local Imports
 from PokeAlarm.Utils import get_gmaps_link, get_applemaps_link, \
@@ -70,6 +71,8 @@ class WeatherEvent(BaseEvent):
                 '' if self.severity_id == 0 else severity_locale,
             'day_or_night_id': self.day_or_night_id,
             'day_or_night_id_3': "{:03}".format(self.day_or_night_id),
-            'day_or_night': locale.get_day_or_night(self.day_or_night_id)
+            'day_or_night': locale.get_day_or_night(self.day_or_night_id),
+
+            'current_timestamp_utc': datetime.utcnow(),
         })
         return dts


### PR DESCRIPTION
## Description
Footer timestamps for Discord
they adjust to the timestamp of the user's device
This is especially useful for expiration timers
Closes #729 

There are a few new time DTS in order to use this
1. monsters - `disappear_time_utc`
2. stops - `expiration_utc`
3. eggs - `hatch_time_utc` and `raid_end_utc`
4. raids - `raid_end_utc`
5. invasions - `expiration_utc`
6. all - `current_timestamp_utc`

This adds the `footer_timestamp` field to Discord alarms for monsters, stops, gyms, eggs, raids, and invasions
(all the others don't have expiration timers)

This field accepts:
1. a boolean `true` or `false` to accept the default timestamp field for that webhook type (see above time DTS list)
a. in the case of eggs, the default is `hatch_time_utc`
2. a string containing the DTS of choice; this is mostly useful on egg webhook types for the `raid_end_utc`
a. this would look like `"footer_timestamp": "<raid_end_utc>"`
b. If you prefer the current time instead of the expiration time, you can use `current_timestamp_utc` instead

Also, instead of putting `true` on every specific webhook type, you can put it on the top level so it's assumed true for all that it's possible on
ex. 
```json
{
  "discord-everything": {
    "active": true,
    "type": "discord",
    "webhook_url": "<webhook>",
    "footer_timestamp": true
  }
}
```

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
People like timestamps for their own region, less date math that way

## How Has This Been Tested?
Lightly, windows 10

## Wiki Update
- [x] This change requires an update to the Wiki.
- [ ] This change does not require an update to the Wiki.

Wiki changes come later if team agrees on naming