### PR TITLE
Updating maps api for Google and improving query strings for accuracy

### DIFF
--- a/PokeAlarm/Utils.py
+++ b/PokeAlarm/Utils.py
@@ -438,20 +438,20 @@ def get_ex_eligible_emoji(ex_eligible):
 
 # Returns a String link to Google Maps Pin at the location
 def get_gmaps_link(lat, lng):
-    latlng = '{:5f},{:5f}'.format(lat, lng)
-    return 'http://maps.google.com/maps?q={}'.format(latlng)
+    latlng = '{:5f}%2C{:5f}'.format(lat, lng)
+    return 'https://www.google.com/maps/dir/?api=1' \
+        + '&destination={}'.format(latlng)
 
 
 # Returns a String link to Apple Maps Pin at the location
 def get_applemaps_link(lat, lng):
-    latlng = '{:5f},{:5f}'.format(lat, lng)
-    return 'http://maps.apple.com/maps?' \
-           + 'daddr={}&z=10&t=s&dirflg=w'.format(latlng)
+    latlng = '{:5f}%2C{:5f}'.format(lat, lng)
+    return 'https://maps.apple.com/maps?daddr={}&t=m'.format(latlng)
 
 
 # Returns a String link to Waze Maps Navigation at the location
 def get_waze_link(lat, lng):
-    latlng = '{:5f},{:5f}'.format(lat, lng)
+    latlng = '{:5f}%2C{:5f}'.format(lat, lng)
     return 'https://waze.com/ul?navigate=yes&ll={}'.format(latlng)
 
 
@@ -464,14 +464,14 @@ def get_static_map_url(settings, api_key=None):  # TODO: optimize formatting
     maptype = settings.get('maptype', 'roadmap')
     zoom = settings.get('zoom', '15')
 
-    center = '{},{}'.format('<lat>', '<lng>')
+    center = '{}%2C{}'.format('<lat>', '<lng>')
     query_center = 'center={}'.format(center)
     query_markers = 'markers=color:red%7C{}'.format(center)
     query_size = 'size={}x{}'.format(width, height)
     query_zoom = 'zoom={}'.format(zoom)
     query_maptype = 'maptype={}'.format(maptype)
 
-    map_ = ('https://maps.googleapis.com/maps/api/staticmap?' +
+    map_ = ('https://www.google.com/maps/api/staticmap?maptype=roadmap' +
             query_center + '&' + query_markers + '&' +
             query_maptype + '&' + query_size + '&' + query_zoom)
 


### PR DESCRIPTION
<!--
 Please make all PRs to the dev branch. The dev branch will be
 periodically pulled into the master branch. This allows time for
 the changes and documentation to be tested before being exposed to
 a wider population.
--->

## Description
This PR corrects a bug identified in #785 wherein the Google Maps API has changed and thus the links being produced are no longer accurate for all devices. I also took the chance to clean up the query string being passed to improve query accuracy by passing url-encoded objects rather than UTF-8. 

This PR also removes the preselector for 'Walking' as the desired Travel Mode for Google & Apple Maps, instead deferring to the user's last chosen travel mode for directions. It also changes the functionality of the `<gmaps>` link to immediately start navigation rather than simply taking you to a map point in the Google Maps app. 

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
<!---
 Why is this change required? What problem does it solve?
 If it fixes an open issue, please link to the issue here.
-->
Resolves an outstanding bug which generates invalid Maps links. 

## How Has This Been Tested?
<!---
 Please describe in detail how you tested your changes. Make sure to
 describe what tests you have performed, your testing environment,
 and if you have used this in a production setting. Please add
 screenshots if appropriate.
-->
Untested

## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change to https://github.com/RocketMap/PokeAlarmWiki.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [ ] This change requires an update to the Wiki.
- [x] This change does not require an update to the Wiki.