### PR TITLE
pvpoke url depending on the locale

### DIFF
--- a/PokeAlarm/Events/MonEvent.py
+++ b/PokeAlarm/Events/MonEvent.py
@@ -278,7 +278,8 @@ class MonEvent(BaseEvent):
                     'levelCap': '50'
                 }),
             'great_pvpoke':
-                'https://pvpoke.com/rankings/all/1500/overall/{}{}/'.format(
+                'https://{}/rankings/all/1500/overall/{}{}/'.format(
+                    locale.get_pvpoke_domain(),
                     re.sub(r'[^A-Za-z0-9\s]+', '',
                            locale.get_english_pokemon_name(self.great_id))
                     .lower().replace(' ', '_'),
@@ -308,7 +309,8 @@ class MonEvent(BaseEvent):
                     'levelCap': '50'
                 }),
             'ultra_pvpoke':
-                'https://pvpoke.com/rankings/all/2500/overall/{}{}/'.format(
+                'https://{}/rankings/all/2500/overall/{}{}/'.format(
+                    locale.get_pvpoke_domain(),
                     re.sub(r'[^A-Za-z0-9\s]+', '',
                            locale.get_english_pokemon_name(self.ultra_id))
                     .lower().replace(' ', '_'),

--- a/PokeAlarm/Locale.py
+++ b/PokeAlarm/Locale.py
@@ -289,3 +289,15 @@ class Locale(object):
 
     def get_item_name(self, item_id):
         return self.__item_names.get(item_id, 'unknown')
+
+    def get_pvpoke_domain(self):
+        if self.name == 'de':
+            return 'de.pvpoke-re.com'
+        elif self.name == 'fr':
+            return 'fr.pvpoke-re.com'
+        elif self.name == 'es':
+            return 'es.pvpoke-re.com'
+        elif self.name == 'pt':
+            return 'pt.pvpoke-re.com'
+        else:
+            return 'pvpoke.com'


### PR DESCRIPTION
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->


<!--
 Please make all PRs to the dev branch. The dev branch will be
 periodically pulled into the master branch. This allows time for
 the changes and documentation to be tested before being exposed to
 a wider population.
--->

## Description
<!-- In detail, describe what your PR adds to PokeAlarm -->

Dynamically change the domain of PvPoke DTS URL for available locales (only DE, FR, ES, PT and EN obviously are supported).

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
<!---
 Why is this change required? What problem does it solve?
 If it fixes an open issue, please link to the issue here.
-->
PvPoke supports multiple languages. So let's use them!
For users, it's more friendly to browse the pages in their own languages as there is a lot of information hard to translate for any users (pokemon name, useful PvP moves and others leaderboard stats).

## How Has This Been Tested?
<!---
 Please describe in detail how you tested your changes. Make sure to
 describe what tests you have performed, your testing environment,
 and if you have used this in a production setting. Please add
 screenshots if appropriate.
-->

I tested it only by changing the `locale: en` line in the config. It worked for each language above.

DE example:
![image](https://user-images.githubusercontent.com/45545471/152422025-dc0eae38-a029-4b02-8f9e-f084d324e541.png)
FR example:
![image](https://user-images.githubusercontent.com/45545471/152421837-bcd8d3ef-c90f-4be8-983e-e17950433e16.png)
EN example (current):
![image](https://user-images.githubusercontent.com/45545471/152421954-992fc9c9-e509-4bbe-bde0-12a1be0bd271.png)

## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change to https://github.com/RocketMap/PokeAlarmWiki.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [ ] This change requires an update to the Wiki.
- [x] This change does not require an update to the Wiki.