### PR TITLE
Revert "Display monsters (ditto) (#778)"

### DIFF
--- a/PokeAlarm/Alarms/Discord/DiscordAlarm.py
+++ b/PokeAlarm/Alarms/Discord/DiscordAlarm.py
@@ -28,10 +28,6 @@ class DiscordAlarm(Alarm):
                 "regular/monsters/<mon_id_3>_<form_id_3>.png"),
             'avatar_url': get_image_url(
                 "regular/monsters/<mon_id_3>_<form_id_3>.png"),
-            'display_icon_url': get_image_url(
-                "regular/monsters/<display_mon_id_3>_<display_form_id_3>.png"),
-            'display_avatar_url': get_image_url(
-                "regular/monsters/<display_mon_id_3>_<display_form_id_3>.png"),
             'title': "A wild <mon_name> has appeared!",
             'url': "<gmaps>",
             'body': "Available until <24h_time> (<time_left>).",
@@ -176,23 +172,14 @@ class DiscordAlarm(Alarm):
     # Set the appropriate settings for each alert
     def create_alert_settings(self, settings, default):
         map = settings.pop('map', self.__map)
-        use_display_icon = settings.pop('use_display_icon', False)
-        use_display_avatar = settings.pop('use_display_avatar', False)
-
         alert = {
             'webhook_url': settings.pop('webhook_url', self.__webhook_url),
             'username': settings.pop('username', default['username']),
-            'avatar_url': settings.pop(
-                'avatar_url',
-                default['display_avatar_url']
-                if use_display_avatar else default['avatar_url']),
+            'avatar_url': settings.pop('avatar_url', default['avatar_url']),
             'disable_embed': parse_boolean(
                 settings.pop('disable_embed', self.__disable_embed)),
             'content': settings.pop('content', default['content']),
-            'icon_url': settings.pop(
-                'icon_url',
-                default['display_icon_url']
-                if use_display_icon else default['icon_url']),
+            'icon_url': settings.pop('icon_url', default['icon_url']),
             'title': settings.pop('title', default['title']),
             'url': settings.pop('url', default['url']),
             'body': settings.pop('body', default['body']),

--- a/PokeAlarm/Alarms/FacebookPage/FacebookPageAlarm.py
+++ b/PokeAlarm/Alarms/FacebookPage/FacebookPageAlarm.py
@@ -27,8 +27,6 @@ class FacebookPageAlarm(Alarm):
             'message': "A wild <mon_name> has appeared!",
             'image': get_image_url(
                 "regular/monsters/<mon_id_3>_<form_id_3>.png"),
-            'display_image': get_image_url(
-                "regular/monsters/<display_mon_id_3>_<display_form_id_3>.png"),
             'link': "<gmaps>",
             'name': "<mon_name>",
             'description': "Available until <24h_time> (<time_left>).",
@@ -150,14 +148,12 @@ class FacebookPageAlarm(Alarm):
 
     # Set the appropriate settings for each alert
     def create_alert_settings(self, settings, default):
-        use_display_image = settings.pop('use_display_image', False)
         alert = {
             'message': settings.pop('message', default['message']),
             'link': settings.pop('link', default['link']),
             'caption': settings.pop('caption', default['caption']),
             'description': settings.pop('description', default['description']),
-            'image': settings.pop('image', default['display_image']
-                                  if use_display_image else default['image']),
+            'image': settings.pop('image', default['image']),
             'name': settings.pop('name', default['name'])
         }
         reject_leftover_parameters(

--- a/PokeAlarm/Alarms/Slack/SlackAlarm.py
+++ b/PokeAlarm/Alarms/Slack/SlackAlarm.py
@@ -27,8 +27,6 @@ class SlackAlarm(Alarm):
             'username': "<mon_name>",
             'icon_url': get_image_url(
                 "regular/monsters/<mon_id_3>_<form_id_3>.png"),
-            'display_icon_url': get_image_url(
-                "regular/monsters/<display_mon_id_3>_<display_form_id_3>.png"),
             'title': "A wild <mon_name> has appeared!",
             'url': "<gmaps>",
             'body': "Available until <24h_time> (<time_left>)."
@@ -145,13 +143,10 @@ class SlackAlarm(Alarm):
     # Set the appropriate settings for each alert
     def create_alert_settings(self, settings, default):
         map = settings.pop('map', self.__map)
-        use_display_icon = settings.pop('use_display_icon', False)
         alert = {
             'channel': settings.pop('channel', self.__default_channel),
             'username': settings.pop('username', default['username']),
-            'icon_url': settings.pop('icon_url', default['display_icon_url']
-                                     if use_display_icon
-                                     else default['icon_url']),
+            'icon_url': settings.pop('icon_url', default['icon_url']),
             'title': settings.pop('title', default['title']),
             'url': settings.pop('url', default['url']),
             'body': settings.pop('body', default['body']),

--- a/PokeAlarm/Alarms/Telegram/TelegramAlarm.py
+++ b/PokeAlarm/Alarms/Telegram/TelegramAlarm.py
@@ -33,10 +33,7 @@ class TelegramAlarm(Alarm):
             'message': "*A wild <mon_name> has appeared!*\n"
                        "Available until <24h_time> (<time_left>).",
             'sticker_url': get_image_url(
-                "telegram/monsters/<mon_id_3>_<form_id_3>.webp"),
-            'display_sticker_url': get_image_url(
-                "telegram/monsters/<display_mon_id_3>_<display_form_id_3>.webp"
-            )
+                "telegram/monsters/<mon_id_3>_<form_id_3>.webp")
         },
         'stops': {
             'message': "*Someone has placed a lure on a Pokestop!*\n"
@@ -208,9 +205,7 @@ class TelegramAlarm(Alarm):
         message = replace(alert.message, dts)
         lat, lng = dts['lat'], dts['lng']
         max_attempts = alert.max_attempts
-        sticker_url = replace(alert.display_sticker_url, dts) \
-            if alert.use_display_sticker is True\
-            else replace(alert.sticker_url, dts)
+        sticker_url = replace(alert.sticker_url, dts)
         self._log.debug(sticker_url)
         # Send Sticker
         if alert.sticker and sticker_url is not None:

--- a/PokeAlarm/Events/MonEvent.py
+++ b/PokeAlarm/Events/MonEvent.py
@@ -145,16 +145,6 @@ class MonEvent(BaseEvent):
         # Rarity
         self.rarity_id = check_for_none(int, data.get('rarity'), Unknown.TINY)
 
-        # Display Monster Information (Generally the real monster is ditto)
-        self.display_monster_id = check_for_none(
-            int, data.get('display_pokemon_id'), 0)
-        self.display_form_id = check_for_none(
-            int, data.get('display_form'), 0)
-        self.display_costume_id = check_for_none(
-            int, data.get('display_costume'), 0)
-        self.display_gender = MonUtils.get_gender_sym(
-            check_for_none(int, data.get('display_gender'), Unknown.TINY))
-
         # Correct this later
         self.name = self.monster_id
         self.geofence = Unknown.REGULAR
@@ -395,24 +385,6 @@ class MonEvent(BaseEvent):
                 "{:.2f}".format(self.weight) if Unknown.is_not(self.weight)
                 else Unknown.SMALL),
             'size': locale.get_size_name(self.size_id),
-
-            # Display Information (Usually when the actual mon is a ditto)
-            'display_mon_id': self.display_monster_id,
-            'display_mon_name': locale.get_pokemon_name(
-                self.display_monster_id),
-            'display_mon_id_3': "{:03}".format(self.display_monster_id),
-            'display_mon_id_2': "{:02}".format(self.display_monster_id),
-            'display_costume_id': self.display_costume_id,
-            'display_costume_id_2': "{:02d}".format(self.display_costume_id),
-            'display_costume_id_3': "{:03d}".format(self.display_costume_id),
-            'display_costume': locale.get_costume_name(
-                self.display_monster_id, self.display_costume_id),
-            'display_form_id': self.display_form_id,
-            'display_form': locale.get_form_name(
-                self.display_monster_id, self.display_form_id),
-            'display_form_id_3': "{:03d}".format(self.display_form_id),
-            'display_form_id_2': "{:02d}".format(self.display_form_id),
-            'display_gender': self.display_gender,
 
             # Misc
             'atk_grade': (


### PR DESCRIPTION
## Description
This PR reverts #778 which introduced an un-intentional bug that breaks Telegram alerts. 

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
<!---
 Why is this change required? What problem does it solve?
 If it fixes an open issue, please link to the issue here.
-->
Telegram was broken by #778, @LegitDongo is working on a fix. 

## How Has This Been Tested?
<!---
 Please describe in detail how you tested your changes. Make sure to
 describe what tests you have performed, your testing environment,
 and if you have used this in a production setting. Please add
 screenshots if appropriate.
-->

## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change to https://github.com/RocketMap/PokeAlarmWiki.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [ ] This change requires an update to the Wiki.
- [x] This change does not require an update to the Wiki.