### PR TITLE
Add time filters

### DIFF
--- a/PokeAlarm/Filters/BaseFilter.py
+++ b/PokeAlarm/Filters/BaseFilter.py
@@ -1,5 +1,6 @@
 # Standard Library Imports
 import logging
+from datetime import datetime, timedelta
 # 3rd Party Imports
 # Local Imports
 from PokeAlarm import Unknown
@@ -73,6 +74,18 @@ class BaseFilter(object):
         # Add check function to our list
         self._check_list.append(check)
         return limit
+
+    def evaluate_time(self, min_time, max_time):
+        if min_time is None:
+            min_time = 0.0
+        if max_time is None:
+            max_time = 60.0 * 60.0 * 24.0
+
+        # Create a function to compare the current time to time range
+        check = CheckTime(min_time, max_time)
+
+        # Add check function to our list
+        self._check_list.append(check)
 
     @staticmethod
     def parse_as_type(kind, param_name, data):
@@ -151,6 +164,29 @@ class BaseFilter(object):
         return allowed
 
     @staticmethod
+    def parse_as_time(param_name, data):
+        """ Parse a time with X:XX format (24h) and convert in seconds"""
+        try:
+            value = data.pop(param_name, None)
+            if value is None:
+                return None
+            else:
+                try:
+                    absolute_time_sec = datetime.strptime(value, '%H:%M')
+                    return (absolute_time_sec - absolute_time_sec.replace(
+                        hour=0, minute=0)).total_seconds()
+                except Exception:
+                    raise ValueError(
+                        'Unable to interpret the value "{}" as a '.format(
+                            value) +
+                        'valid X:XX format for parameter {}.", '.format(
+                            param_name))
+        except Exception:
+            raise ValueError(
+                'Unable to interpret the value "{}" as a '.format(value) +
+                'valid  X:XX format for parameter {}.", '.format(param_name))
+
+    @ staticmethod
     def parse_as_dict(key_type, value_type, param_name, data):
         """ Parse and convert a dict of values into a specific types."""
         values = data.pop(param_name, {})
@@ -189,5 +225,32 @@ class CheckFunction(object):
 
         if result is False:  # Log rejection
             filtr.reject(event, self._attr_name, value, self._limit)
+
+        return result
+
+
+class CheckTime(object):
+    """ Function used to check if a timestamp passes or not. """
+
+    def __init__(self, min_time, max_time):
+        self._min_time = min_time
+        self._max_time = max_time
+
+    def __call__(self, filtr, event):
+        now = datetime.now()
+        current_time = (now - now.replace(hour=0, minute=0,
+                        second=0)).total_seconds()
+        if self._min_time <= self._max_time:
+            result = (self._min_time <=
+                      current_time and current_time <= self._max_time)
+        else:
+            result = (self._min_time <=
+                      current_time or current_time <= self._max_time)
+
+        if result is False:  # Log rejection
+            filtr.reject(event, 'time range',
+                         str(timedelta(seconds=current_time)),
+                         [str(timedelta(seconds=self._min_time)),
+                          str(timedelta(seconds=self._max_time))])
 
         return result

--- a/PokeAlarm/Filters/BaseFilter.py
+++ b/PokeAlarm/Filters/BaseFilter.py
@@ -76,6 +76,9 @@ class BaseFilter(object):
         return limit
 
     def evaluate_time(self, min_time, max_time):
+        if min_time is None and max_time is None:
+            return None  # limit not set
+
         if min_time is None:
             min_time = 0.0
         if max_time is None:
@@ -235,11 +238,15 @@ class CheckTime(object):
     def __init__(self, min_time, max_time):
         self._min_time = min_time
         self._max_time = max_time
+        self._override_time = None
 
     def __call__(self, filtr, event):
-        now = datetime.now()
-        current_time = (now - now.replace(hour=0, minute=0,
-                        second=0)).total_seconds()
+        if self._override_time is not None:
+            current_time = self._override_time
+        else:
+            now = datetime.now()
+            current_time = (now - now.replace(hour=0, minute=0,
+                                              second=0)).total_seconds()
         if self._min_time <= self._max_time:
             result = (self._min_time <=
                       current_time and current_time <= self._max_time)
@@ -254,3 +261,8 @@ class CheckTime(object):
                           str(timedelta(seconds=self._max_time))])
 
         return result
+
+    def override_time(self, current_time):
+        absolute_time_sec = datetime.strptime(current_time, '%H:%M')
+        self._override_time = (absolute_time_sec - absolute_time_sec.replace(
+            hour=0, minute=0)).total_seconds()

--- a/PokeAlarm/Filters/EggFilter.py
+++ b/PokeAlarm/Filters/EggFilter.py
@@ -83,6 +83,10 @@ class EggFilter(BaseFilter):
         # Geofences
         self.geofences = BaseFilter.parse_as_list(str, 'geofences', data)
 
+        # Time
+        self.evaluate_time(BaseFilter.parse_as_time(
+            'min_time', data), BaseFilter.parse_as_time('max_time', data))
+
         # Custom DTS
         self.custom_dts = BaseFilter.parse_as_dict(
             str, str, 'custom_dts', data)

--- a/PokeAlarm/Filters/GruntFilter.py
+++ b/PokeAlarm/Filters/GruntFilter.py
@@ -54,6 +54,10 @@ class GruntFilter(BaseFilter):
         # Geofences
         self.geofences = BaseFilter.parse_as_list(str, 'geofences', data)
 
+        # Time
+        self.evaluate_time(BaseFilter.parse_as_time(
+            'min_time', data), BaseFilter.parse_as_time('max_time', data))
+
         # Custom DTS
         self.custom_dts = BaseFilter.parse_as_dict(
             str, str, 'custom_dts', data)

--- a/PokeAlarm/Filters/GymFilter.py
+++ b/PokeAlarm/Filters/GymFilter.py
@@ -60,6 +60,10 @@ class GymFilter(BaseFilter):
         # Geofences
         self.geofences = BaseFilter.parse_as_list(str, 'geofences', data)
 
+        # Time
+        self.evaluate_time(BaseFilter.parse_as_time(
+            'min_time', data), BaseFilter.parse_as_time('max_time', data))
+
         # Custom DTS
         self.custom_dts = BaseFilter.parse_as_dict(
             str, str, 'custom_dts', data)

--- a/PokeAlarm/Filters/MonFilter.py
+++ b/PokeAlarm/Filters/MonFilter.py
@@ -196,6 +196,10 @@ class MonFilter(BaseFilter):
         # Geofences
         self.geofences = BaseFilter.parse_as_list(str, 'geofences', data)
 
+        # Time
+        self.evaluate_time(BaseFilter.parse_as_time(
+            'min_time', data), BaseFilter.parse_as_time('max_time', data))
+
         # Custom DTS
         self.custom_dts = BaseFilter.parse_as_dict(
             str, str, 'custom_dts', data)

--- a/PokeAlarm/Filters/QuestFilter.py
+++ b/PokeAlarm/Filters/QuestFilter.py
@@ -102,6 +102,10 @@ class QuestFilter(BaseFilter):
         # Geofences
         self.geofences = BaseFilter.parse_as_list(str, 'geofences', data)
 
+        # Time
+        self.evaluate_time(BaseFilter.parse_as_time(
+            'min_time', data), BaseFilter.parse_as_time('max_time', data))
+
         # Custom DTS
         self.custom_dts = BaseFilter.parse_as_dict(
             str, str, 'custom_dts', data)

--- a/PokeAlarm/Filters/RaidFilter.py
+++ b/PokeAlarm/Filters/RaidFilter.py
@@ -142,6 +142,10 @@ class RaidFilter(BaseFilter):
         # Geofences
         self.geofences = BaseFilter.parse_as_list(str, 'geofences', data)
 
+        # Time
+        self.evaluate_time(BaseFilter.parse_as_time(
+            'min_time', data), BaseFilter.parse_as_time('max_time', data))
+
         # Custom DTS
         self.custom_dts = BaseFilter.parse_as_dict(
             str, str, 'custom_dts', data)

--- a/PokeAlarm/Filters/StopFilter.py
+++ b/PokeAlarm/Filters/StopFilter.py
@@ -47,6 +47,10 @@ class StopFilter(BaseFilter):
         # Geofences
         self.geofences = BaseFilter.parse_as_list(str, 'geofences', data)
 
+        # Time
+        self.evaluate_time(BaseFilter.parse_as_time(
+            'min_time', data), BaseFilter.parse_as_time('max_time', data))
+
         # Custom DTS
         self.custom_dts = BaseFilter.parse_as_dict(
             str, str, 'custom_dts', data)

--- a/PokeAlarm/Filters/WeatherFilter.py
+++ b/PokeAlarm/Filters/WeatherFilter.py
@@ -39,6 +39,10 @@ class WeatherFilter(BaseFilter):
         # Geofences
         self.geofences = BaseFilter.parse_as_list(str, 'geofences', data)
 
+        # Time
+        self.evaluate_time(BaseFilter.parse_as_time(
+            'min_time', data), BaseFilter.parse_as_time('max_time', data))
+
         # Custom DTS
         self.custom_dts = BaseFilter.parse_as_dict(
             str, str, 'custom_dts', data)

--- a/docs/configuration/filters/egg-filters.rst
+++ b/docs/configuration/filters/egg-filters.rst
@@ -68,6 +68,8 @@ min_time_left   Minimum time (in seconds) until monster despawns.      ``1000``
 max_time_left   Maximum time (in seconds) until monster despawns.      ``2400``
 weather         Accepted weathers, by id or name.                      ``["Clear",2]``
 geofences       See :ref:`geofences_filters` page on 'Geofences'       ``["geofence1","geofence2"]``
+min_time        See :ref:`time_dts_filters` page on 'Time DTS'         ``8:30``
+max_time        See :ref:`time_dts_filters` page on 'Time DTS'         ``22:00``
 custom_dts      See :ref:`custom_dts_filters` page on 'Custom DTS'     ``{"dts1":"substitution"}``
 is_missing_info See :ref:`missing_info_filters` page on 'Missing Info' ``true`` or ``false``
 

--- a/docs/configuration/filters/gym-filters.rst
+++ b/docs/configuration/filters/gym-filters.rst
@@ -65,6 +65,8 @@ min_dist        Min distance of event from set location in miles       ``0.0`` *
 max_dist        Max distance of event from set location in miles       ``1000.0`` *
                 or meters (depending on settings).
 geofences       See :ref:`geofences_filters` page on 'Geofences'       ``["geofence1","geofence2"]``
+min_time        See :ref:`time_dts_filters` page on 'Time DTS'         ``8:30``
+max_time        See :ref:`time_dts_filters` page on 'Time DTS'         ``22:00``
 custom_dts      See :ref:`custom_dts_filters` page on 'Custom DTS'     ``{"dts1":"substitution"}``
 is_missing_info See :ref:`missing_info_filters` page on 'Missing Info' ``true`` or ``false``
 =============== ====================================================== ==============================

--- a/docs/configuration/filters/index.rst
+++ b/docs/configuration/filters/index.rst
@@ -171,7 +171,7 @@ Missing Information
 
 As described on the :doc:`../events/index` page, sometimes an Event is missing
 information. Erring on the side of caution, a Filter will skip a restriction if
-the information needed to check it is missing. If your use the ``min_iv`` info,
+the information needed to check it is missing. If you use the ``min_iv`` info,
 but the IV is ``unknown`` for any reason, then by default Filter will skip
 checking a restriction as if it wasn't specified.
 
@@ -219,6 +219,33 @@ just have to configure the geofences like this:
 
   "filter_name_1":{
       "geofences":["all"]
+  }
+
+.. _time_dts_filters:
+
+Time DTS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Time DTS** is used to filter an alarm depending on the local time of the
+PA server.
+The range can be specified using ``min_time`` and ``max_time`` DTS for any
+filter types.
+``min_time`` is the minimum local time to trigger an alarm
+(default: 00:00 from current day).
+``max_time`` is the maximum local time to trigger an alarm
+(default: 00:00 from next day).
+These DTS use the 24h format time (X:XX) (e.g. 4:00, 10:00, 20:00).
+
+For example, if only ``"min_time": "13:42"`` is specified, an alarm can
+be triggered between 13:42 and 23:59:59.
+If ``"min_time": "23:00"`` and ``"max_time": "1:00"`` are speficied,
+the alarms can be triggered between 23:00:00 from day 1 to 1:00:00 from day 2.
+
+.. code-block:: json
+
+  "filter_daytime":{
+      "min_time": "8:00",
+      "max_time": "22:00"
   }
 
 .. _custom_dts_filters:

--- a/docs/configuration/filters/invasion-filters.rst
+++ b/docs/configuration/filters/invasion-filters.rst
@@ -60,6 +60,8 @@ max_dist        Max distance of event from set location in miles       ``1000.0`
 min_time_left   Minimum time (in seconds) until monster despawns.      ``1000``
 max_time_left   Maximum time (in seconds) until monster despawns.      ``2400``
 geofences       See :ref:`geofences_filters` page on 'Geofences'       ``["geofence1","geofence2"]``
+min_time        See :ref:`time_dts_filters` page on 'Time DTS'         ``8:30``
+max_time        See :ref:`time_dts_filters` page on 'Time DTS'         ``22:00``
 custom_dts      See :ref:`custom_dts_filters` page on 'Custom DTS'     ``{"dts1":"substitution"}``
 is_missing_info See :ref:`missing_info_filters` page on 'Missing Info' ``true`` or ``false``
 =============== ====================================================== ==============================

--- a/docs/configuration/filters/monster-filters.rst
+++ b/docs/configuration/filters/monster-filters.rst
@@ -125,6 +125,8 @@ weather            Accepted weather conditions, by id or name.            ``["Cl
 boosted_weather    Accepted boosted weather condition, by id or name.     ``["Clear",2]``
 is_boosted_weather Accepts or denies based off boosted weather condition. ``true``
 geofences          See :ref:`geofences_filters` page on 'Geofences'       ``["geofence1","geofence2"]``
+min_time           See :ref:`time_dts_filters` page on 'Time DTS'         ``8:30``
+max_time           See :ref:`time_dts_filters` page on 'Time DTS'         ``22:00``
 custom_dts         See :ref:`custom_dts_filters` page on 'Custom DTS'     ``{"dts1":"substitution"}``
 is_missing_info    See :ref:`missing_info_filters` page on 'Missing Info' ``true`` or ``false``
 ================== ====================================================== ==============================

--- a/docs/configuration/filters/quest-filters.rst
+++ b/docs/configuration/filters/quest-filters.rst
@@ -93,9 +93,11 @@ min_dist        Min distance of event from set location in miles       ``0.0`` *
                 or meters (depending on settings).
 max_dist        Max distance of event from set location in miles       ``1000.0`` *
                 or meters (depending on settings).
---min_time_left   Minimum time (in seconds) until monster despawns.      ``1000``
---max_time_left   Maximum time (in seconds) until monster despawns.      ``2400``
+min_time_left   Minimum time (in seconds) until monster despawns.      ``1000``
+max_time_left   Maximum time (in seconds) until monster despawns.      ``2400``
 geofences       See :ref:`geofences_filters` page on 'Geofences'       ``["geofence1","geofence2"]``
+min_time        See :ref:`time_dts_filters` page on 'Time DTS'         ``8:30``
+max_time        See :ref:`time_dts_filters` page on 'Time DTS'         ``22:00``
 custom_dts      See :ref:`custom_dts_filters` page on 'Custom DTS'     ``{"dts1":"substitution"}``
 is_missing_info See :ref:`missing_info_filters` page on 'Missing Info' ``true`` or ``false``
 =============== ====================================================== ==============================

--- a/docs/configuration/filters/raid-filters.rst
+++ b/docs/configuration/filters/raid-filters.rst
@@ -75,6 +75,8 @@ min_time_left   Minimum time (in seconds) until monster despawns.      ``1000``
 max_time_left   Maximum time (in seconds) until monster despawns.      ``2400``
 weather         Accepted weathers, by id or name.                      ``["Clear",2]``
 geofences       See :ref:`geofences_filters` page on 'Geofences'       ``["geofence1","geofence2"]``
+min_time        See :ref:`time_dts_filters` page on 'Time DTS'         ``8:30``
+max_time        See :ref:`time_dts_filters` page on 'Time DTS'         ``22:00``
 custom_dts      See :ref:`custom_dts_filters` page on 'Custom DTS'     ``{"dts1":"substitution"}``
 is_missing_info See :ref:`missing_info_filters` page on 'Missing Info' ``true`` or ``false``
 =============== ====================================================== ==============================

--- a/docs/configuration/filters/stop-filters.rst
+++ b/docs/configuration/filters/stop-filters.rst
@@ -59,6 +59,8 @@ max_dist        Max distance of event from set location in miles       ``1000.0`
 min_time_left   Minimum time (in seconds) until monster despawns.      ``1000``
 max_time_left   Maximum time (in seconds) until monster despawns.      ``2400``
 geofences       See :ref:`geofences_filters` page on 'Geofences'       ``["geofence1","geofence2"]``
+min_time        See :ref:`time_dts_filters` page on 'Time DTS'         ``8:30``
+max_time        See :ref:`time_dts_filters` page on 'Time DTS'         ``22:00``
 custom_dts      See :ref:`custom_dts_filters` page on 'Custom DTS'     ``{"dts1":"substitution"}``
 is_missing_info See :ref:`missing_info_filters` page on 'Missing Info' ``true`` or ``false``
 =============== ====================================================== ==============================

--- a/docs/configuration/filters/weather-filters.rst
+++ b/docs/configuration/filters/weather-filters.rst
@@ -46,6 +46,8 @@ min_dist        Min distance of event from set location in miles       ``0.0`` *
 max_dist        Max distance of event from set location in miles       ``1000.0`` *
                 or meters (depending on settings).
 geofences       See :ref:`geofences_filters` page on 'Geofences'       ``["geofence1","geofence2"]``
+min_time        See :ref:`time_dts_filters` page on 'Time DTS'         ``8:30``
+max_time        See :ref:`time_dts_filters` page on 'Time DTS'         ``22:00``
 custom_dts      See :ref:`custom_dts_filters` page on 'Custom DTS'     ``{"dts1":"substitution"}``
 weather         A list of weather by name or ids.                      ``["Clear", 2]``
 day_or_night    A list of the time of day by id or name                ``["Day", 2]``

--- a/tests/filters/test_monster_filter.py
+++ b/tests/filters/test_monster_filter.py
@@ -295,6 +295,55 @@ class TestMonsterFilter(unittest.TestCase):
         self.pass_vals = [198, 261]
         self.fail_vals = [1, 4]
 
+    def test_time_range(self):
+        # Create a time filter with min_time and max_time set
+        filt = self.gen_filter(
+            {'min_time': "22:58", 'max_time': "0:25"})
+
+        # Test passing
+        for t in ["23:15", "22:58", "0:00", "0:25"]:
+            filt._check_list[0].override_time(t)
+            event = self.gen_event({"encounter_id": "1"})
+            self.assertTrue(filt.check_event(event))
+
+        # Test failing
+        for t in ["22:57", "10:00", "20:50", "0:26"]:
+            filt._check_list[0].override_time(t)
+            event = self.gen_event({"encounter_id": "1"})
+            self.assertFalse(filt.check_event(event))
+
+        # Create a time filter with only min_time set
+        filt = self.gen_filter(
+            {'min_time': "22:58"})
+
+        # Test passing
+        for t in ["23:15", "22:58", "23:59"]:
+            filt._check_list[0].override_time(t)
+            event = self.gen_event({"encounter_id": "1"})
+            self.assertTrue(filt.check_event(event))
+
+        # Test failing
+        for t in ["22:57", "10:00", "0:50", "0:00"]:
+            filt._check_list[0].override_time(t)
+            event = self.gen_event({"encounter_id": "1"})
+            self.assertFalse(filt.check_event(event))
+
+        # Create a time filter with only max_time set
+        filt = self.gen_filter(
+            {'max_time': "0:25"})
+
+        # Test passing
+        for t in ["0:00", "0:25"]:
+            filt._check_list[0].override_time(t)
+            event = self.gen_event({"encounter_id": "1"})
+            self.assertTrue(filt.check_event(event))
+
+        # Test failing
+        for t in ["22:57", "10:00", "20:50", "0:26"]:
+            filt._check_list[0].override_time(t)
+            event = self.gen_event({"encounter_id": "1"})
+            self.assertFalse(filt.check_event(event))
+
     def test_time_left(self):
         # Create the filter
         filt = self.gen_filter(


### PR DESCRIPTION
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->


<!--
 Please make all PRs to the dev branch. The dev branch will be
 periodically pulled into the master branch. This allows time for
 the changes and documentation to be tested before being exposed to
 a wider population.
--->

## Description
<!-- In detail, describe what your PR adds to PokeAlarm -->
The new filters DTS (`min_time` and `max_time`) allow users to specify a time range in which an alarm can be triggered.
These DTS use the local time of the PA server.

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
<!---
 Why is this change required? What problem does it solve?
 If it fixes an open issue, please link to the issue here.
-->
There was no way to filter an alarm using a time range and the only workaround was to stop or reload PA using CRON.
These filters can also be used to only trigger alarms during the daytime, a community day or a spotlight hour.
This one also closes #690.

## How Has This Been Tested?
<!---
 Please describe in detail how you tested your changes. Make sure to
 describe what tests you have performed, your testing environment,
 and if you have used this in a production setting. Please add
 screenshots if appropriate.
-->
Given the current time changes depending on... the current time, I can't really write tests for this one as it would depends of the time where it's tested.

What I tried is multiples filters with different `min_time` and `max_time` values. From what I tested, I didn't find specific values where the time filters failed.

## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change to https://github.com/RocketMap/PokeAlarmWiki.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [x] This change requires an update to the Wiki.
- [ ] This change does not require an update to the Wiki.

Included in this PR.