### PR TITLE
Package update for PokeAlarm doc

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ pytz==2019.3
 portalocker==1.5.2
 requests==2.22.0
 greenlet==0.4.13
-itsdangerous==2.0.1
+itsdangerous==2.0.1; python_version >= '3'
+itsdangerous==1.1.0; python_version < '3'


### PR DESCRIPTION
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->


<!--
 Please make all PRs to the dev branch. The dev branch will be
 periodically pulled into the master branch. This allows time for
 the changes and documentation to be tested before being exposed to
 a wider population.
--->

## Description
<!-- In detail, describe what your PR adds to PokeAlarm -->
(DOC ONLY) Use a compatible package version for `itsdangerous` with Python 2

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
<!---
 Why is this change required? What problem does it solve?
 If it fixes an open issue, please link to the issue here.
-->
Given PokeAlarm doc is still generated using Python 2.7... 🤦, it's not generated and updated anymore since `itsdangerous` was pinned to v2.0.1 (PR #811).
This is a workaround to use a different version of an incompatible package (doc only) waiting to migrate ReadtheDocs to Python 3.

First build log failing: https://readthedocs.org/projects/pa/builds/16188438/
Full build list: https://readthedocs.org/projects/pa/builds/

## How Has This Been Tested?
<!---
 Please describe in detail how you tested your changes. Make sure to
 describe what tests you have performed, your testing environment,
 and if you have used this in a production setting. Please add
 screenshots if appropriate.
-->
Tested by forcing an update of requirements and only `itsdangerous` 2.0.1 is requested and downloaded when using Python 3. So all is good!

## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change to https://github.com/RocketMap/PokeAlarmWiki.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [ ] This change requires an update to the Wiki.
- [x] This change does not require an update to the Wiki.