### PR TITLE
Add signed GMaps requests for static maps URL

### DIFF
--- a/PokeAlarm/Alarms/Discord/DiscordAlarm.py
+++ b/PokeAlarm/Alarms/Discord/DiscordAlarm.py
@@ -5,8 +5,9 @@ import requests
 
 # Local Imports
 from PokeAlarm.Alarms import Alarm
-from PokeAlarm.Utils import parse_boolean, get_static_map_url, \
-    reject_leftover_parameters, require_and_remove_key, get_image_url
+from PokeAlarm.Utils import parse_boolean, get_gmaps_static_url, \
+    reject_leftover_parameters, require_and_remove_key, get_image_url, \
+    sign_gmaps_static_url
 
 try_sending = Alarm.try_sending
 replace = Alarm.replace
@@ -115,7 +116,8 @@ class DiscordAlarm(Alarm):
     }
 
     # Gather settings and create alarm
-    def __init__(self, mgr, settings, max_attempts, static_map_key):
+    def __init__(self, mgr, settings, max_attempts, static_map_key,
+                 signing_secret_key):
         self._log = mgr.get_child_logger("alarms")
         # Required Parameters
         self.__webhook_url = require_and_remove_key(
@@ -131,6 +133,7 @@ class DiscordAlarm(Alarm):
         self.__avatar_url = settings.pop('avatar_url', "")
         self.__map = settings.pop('map', {})
         self.__static_map_key = static_map_key
+        self.__signing_secret_key = signing_secret_key
         self.__timestamp = settings.pop('footer_timestamp', False)
 
         # Set Alert Parameters
@@ -201,7 +204,7 @@ class DiscordAlarm(Alarm):
             'body': settings.pop('body', default['body']),
             'fields': settings.pop('fields', []),
             'map': map if isinstance(map, str) else
-            get_static_map_url(map, self.__static_map_key)
+            get_gmaps_static_url(map, self.__static_map_key)
         }
 
         timestamp = settings.pop('footer_timestamp', self.__timestamp)
@@ -236,12 +239,15 @@ class DiscordAlarm(Alarm):
                     'lat': info['lat'],
                     'lng': info['lng']
                 }
+                static_map_url = replace(alert['map'],
+                                         coords if not
+                                         isinstance(alert['map'], str)
+                                         else info)
+                if self.__signing_secret_key is not None:
+                    static_map_url = sign_gmaps_static_url(
+                        static_map_url, self.__signing_secret_key)
                 payload['embeds'][0]['image'] = {
-                    'url':
-                        replace(alert['map'],
-                                coords if not
-                                isinstance(alert['map'], str)
-                                else info)
+                    'url': static_map_url
                 }
 
             if 'timestamp' in alert:

--- a/PokeAlarm/Alarms/Discord/DiscordAlarm.py
+++ b/PokeAlarm/Alarms/Discord/DiscordAlarm.py
@@ -235,17 +235,19 @@ class DiscordAlarm(Alarm):
             }]
 
             if alert['map'] is not None:
-                coords = {
-                    'lat': info['lat'],
-                    'lng': info['lng']
-                }
-                static_map_url = replace(alert['map'],
-                                         coords if not
-                                         isinstance(alert['map'], str)
-                                         else info)
-                if self.__signing_secret_key is not None:
-                    static_map_url = sign_gmaps_static_url(
-                        static_map_url, self.__signing_secret_key)
+                static_map_url = ""
+                if not isinstance(alert['map'], str):
+                    coords = {
+                        'lat': info['lat'],
+                        'lng': info['lng']
+                    }
+                    static_map_url = replace(alert['map'], coords)
+                else:
+                    static_map_url = replace(alert['map'], info)
+                    if self.__signing_secret_key is not None:
+                        static_map_url = sign_gmaps_static_url(
+                            static_map_url, self.__signing_secret_key)
+
                 payload['embeds'][0]['image'] = {
                     'url': static_map_url
                 }

--- a/PokeAlarm/Alarms/Slack/SlackAlarm.py
+++ b/PokeAlarm/Alarms/Slack/SlackAlarm.py
@@ -168,23 +168,26 @@ class SlackAlarm(Alarm):
 
     # Send Alert to Slack
     def send_alert(self, alert, info):
-        coords = {
-            'lat': info['lat'],
-            'lng': info['lng']
-        }
         attachments = None
         if alert['map'] is not None:
-            static_map_url = replace(alert['map'],
-                                     info if
-                                     isinstance(map, str)
-                                     else coords)
-            if self.__signing_secret_key is not None:
-                static_map_url = sign_gmaps_static_url(
-                    static_map_url, self.__signing_secret_key)
+            static_map_url = ""
+            if not isinstance(alert['map'], str):
+                coords = {
+                    'lat': info['lat'],
+                    'lng': info['lng']
+                }
+                static_map_url = replace(alert['map'], coords)
+            else:
+                static_map_url = replace(alert['map'], info)
+                if self.__signing_secret_key is not None:
+                    static_map_url = sign_gmaps_static_url(
+                        static_map_url, self.__signing_secret_key)
+
             attachments = [{
                 'fallback': 'Map_Preview',
                 'image_url': static_map_url
             }]
+
         self.send_message(
             channel=replace(alert['channel'], info),
             username=replace(alert['username'], info),

--- a/PokeAlarm/Alarms/Slack/SlackAlarm.py
+++ b/PokeAlarm/Alarms/Slack/SlackAlarm.py
@@ -6,8 +6,9 @@ from slack import WebClient
 
 # Local Imports
 from PokeAlarm.Alarms import Alarm
-from PokeAlarm.Utils import parse_boolean, get_static_map_url, \
-    require_and_remove_key, reject_leftover_parameters, get_image_url
+from PokeAlarm.Utils import parse_boolean, get_gmaps_static_url, \
+    require_and_remove_key, reject_leftover_parameters, get_image_url, \
+    sign_gmaps_static_url
 
 try_sending = Alarm.try_sending
 replace = Alarm.replace
@@ -90,7 +91,7 @@ class SlackAlarm(Alarm):
     }
 
     # Gather settings and create alarm
-    def __init__(self, mgr, settings, static_map_key):
+    def __init__(self, mgr, settings, static_map_key, signing_secret_key):
         self._log = mgr.get_child_logger("alarms")
 
         # Required Parameters
@@ -107,6 +108,7 @@ class SlackAlarm(Alarm):
         self.__startup_text = settings.pop('startup_text', "")
         self.__map = settings.pop('map', {})
         self.__static_map_key = static_map_key
+        self.__signing_secret_key = signing_secret_key
 
         # Optional Alert Parameters
         self.__pokemon = self.create_alert_settings(
@@ -159,7 +161,7 @@ class SlackAlarm(Alarm):
             'url': settings.pop('url', default['url']),
             'body': settings.pop('body', default['body']),
             'map': map if isinstance(map, str) else
-            get_static_map_url(map, self.__static_map_key)
+            get_gmaps_static_url(map, self.__static_map_key)
         }
         reject_leftover_parameters(settings, "'Alert level in Slack alarm.")
         return alert
@@ -170,12 +172,19 @@ class SlackAlarm(Alarm):
             'lat': info['lat'],
             'lng': info['lng']
         }
-        attachments = [{
-            'fallback': 'Map_Preview',
-            'image_url':
-                replace(alert['map'],
-                        info if isinstance(map, str) else coords)
-        }] if alert['map'] is not None else None
+        attachments = None
+        if alert['map'] is not None:
+            static_map_url = replace(alert['map'],
+                                     info if
+                                     isinstance(map, str)
+                                     else coords)
+            if self.__signing_secret_key is not None:
+                static_map_url = sign_gmaps_static_url(
+                    static_map_url, self.__signing_secret_key)
+            attachments = [{
+                'fallback': 'Map_Preview',
+                'image_url': static_map_url
+            }]
         self.send_message(
             channel=replace(alert['channel'], info),
             username=replace(alert['username'], info),

--- a/PokeAlarm/Alarms/__init__.py
+++ b/PokeAlarm/Alarms/__init__.py
@@ -2,12 +2,13 @@ from PokeAlarm.Utils import require_and_remove_key
 from .Alarm import Alarm  # noqa F401
 
 
-def alarm_factory(mgr, settings, max_attempts, api_key):
+def alarm_factory(mgr, settings, max_attempts, api_key, signing_secret_key):
     kind = require_and_remove_key(
         'type', settings, "Alarm objects in Alarms file.")
     if kind == 'discord':
         from PokeAlarm.Alarms.Discord import DiscordAlarm
-        return DiscordAlarm(mgr, settings, max_attempts, api_key)
+        return DiscordAlarm(mgr, settings, max_attempts, api_key,
+                            signing_secret_key)
     elif kind == 'facebook_page':
         from PokeAlarm.Alarms.FacebookPage import FacebookPageAlarm
         return FacebookPageAlarm(mgr, settings)
@@ -16,7 +17,7 @@ def alarm_factory(mgr, settings, max_attempts, api_key):
         return PushbulletAlarm(mgr, settings)
     elif kind == 'slack':
         from PokeAlarm.Alarms.Slack import SlackAlarm
-        return SlackAlarm(mgr, settings, api_key)
+        return SlackAlarm(mgr, settings, api_key, signing_secret_key)
     elif kind == 'telegram':
         from PokeAlarm.Alarms.Telegram import TelegramAlarm
         return TelegramAlarm(mgr, settings)

--- a/PokeAlarm/LocationServices/GMaps.py
+++ b/PokeAlarm/LocationServices/GMaps.py
@@ -6,8 +6,8 @@ import time
 import json
 import traceback
 # 3rd Party Imports
+from requests.packages.urllib3.util import Retry
 import requests
-from requests.packages.urllib3.util.retry import Retry
 from gevent.lock import Semaphore
 # Local Imports
 from PokeAlarm import Unknown
@@ -168,7 +168,7 @@ class GMaps(object):
 
     @synchronize_with()
     def reverse_geocode(self, latlng, language='en'):
-        # type: (tuple) -> dict
+        # type: (tuple, str) -> dict
         """ Returns the reverse geocode DTS associated with 'lat,lng'. """
         latlng = '{:.5f},{:.5f}'.format(latlng[0], latlng[1])
         # Check for memoized results

--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -29,8 +29,9 @@ Rule = namedtuple('Rule', ['filter_names', 'alarm_names'])
 
 
 class Manager(object):
-    def __init__(self, name, google_key, locale, units, timezone, time_limit,
-                 max_attempts, location, cache_type, geofence_file, debug):
+    def __init__(self, name, google_key, google_signing_key, locale, units,
+                 timezone, time_limit, max_attempts, location, cache_type,
+                 geofence_file, debug):
         # Set the name of the Manager
         self.name = str(name).lower()
         self._log = self._create_logger(self.name)
@@ -40,10 +41,13 @@ class Manager(object):
 
         # Get the Google Maps AP# TODO: Improve error checking
         self._google_key = None
+        self._google_signing_key = None
         self._gmaps_service = None
         if str(google_key).lower() != 'none':
             self._google_key = google_key
             self._gmaps_service = GMaps(google_key)
+            if str(google_signing_key).lower() != 'none':
+                self._google_signing_key = google_signing_key
         self._gmaps_reverse_geocode = False
         self._gmaps_distance_matrix = set()
 
@@ -348,7 +352,8 @@ class Manager(object):
             raise ValueError("Unable to add new Alarm: Alarm with the name "
                              "{} already exists!".format(name))
         alarm = Alarms.alarm_factory(
-            self, settings, self._max_attempts, self._google_key)
+            self, settings, self._max_attempts, self._google_key,
+            self._google_signing_key)
         self._alarms[name] = alarm
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -67,6 +67,7 @@
 # GMaps Settings
 ################
 #gmaps-key:                     # Google Maps API Key (default=None)
+#gmaps-signing-secret:          # Google Maps Signing Secret (default=None)
 #gmaps-rev-geocode: yes         # Enable Reverse Geocoded DTS. (default='no')
                                 # Note: This requires the Reverse Geocoding API to be enabled on your GMAPs key.
 #gmaps-dm-walk: yes             # Enable Walking DM DTS. (default='no')

--- a/docs/configuration/server-settings.md
+++ b/docs/configuration/server-settings.md
@@ -112,6 +112,8 @@ optional arguments:
                         "America/Los_Angeles"
   -k GMAPS_KEY, --gmaps-key GMAPS_KEY
                         Specify a Google API Key to use.
+  --gmaps-signing-secret SIGNING_SECRET
+                        Specify a Google API Signing Secret.
   --gmaps-rev-geocode GMAPS_REV_GEOCODE
                         Enable Walking Distance Matrix DTS.
   --gmaps-dm-walk GMAPS_DM_WALK
@@ -211,6 +213,7 @@ You can manually specify a configuration file with either the `-cf` or
 # GMaps Settings
 ################
 #gmaps-key:                     # Google Maps API Key (default=None)
+#gmaps-signing-secret:          # Google Maps Signing Secret (default=None)
 #gmaps-rev-geocode: yes         # Enable Reverse Geocoded DTS. (default='no')
                                 # Note: This requires the Reverse Geocoding API to be enabled on your GMAPs key.
 #gmaps-dm-walk: yes             # Enable Walking DM DTS. (default='no')

--- a/docs/miscellaneous/location-services.rst
+++ b/docs/miscellaneous/location-services.rst
@@ -126,7 +126,7 @@ API** at the middle bottom.
 
 .. image:: ../images/14_here_is_your_key.png
 
-To find your key later, click on the blue **Credentials** button at the left.
+14. To find your key later, click on the blue **Credentials** button at the left.
 
 .. image:: ../images/15_find_your_key.png
 
@@ -181,6 +181,24 @@ There are 2 methods to start **PokeAlarm** with your Google Maps API key:
 2. Add ``key:YOUR_GOOGLE_MAPS_API_KEY`` to ``config.ini`` located in the
    ``config`` subfolder of your PokeAlarm installation, then run the command
    ``python3 start_pokealarm.py``.
+
+
+Securing your API requests
+-------------------------------------
+
+PokeAlarm supports the signed requests to secure your Static Maps API requests using a secret hash.
+This step is optional but recommended as it will prevent someone to use your API key to generate
+additional requests for his own use.
+
+The signing secret can be found in the `Credentials <https://console.cloud.google.com/google/maps-apis/credentials>`_
+page by selecting **Generate Secret**. Once you got it, add it to ``gmaps-signing-secret`` in your
+config file. All the static maps requests will now be signed.
+
+Now you can disable the unsigned requests to prevent someone to use your key. To do so, go to
+`Google Maps Quotas <https://console.cloud.google.com/google/maps-apis/quotas>`_ and select
+**Maps Static API**. Open **Unsigned requests (if URL signing secret is defined)** and set the 3 limits
+('par day', 'per minute' and 'per minute per user') to 0. Now, anyone who want to make a request
+with your key need to know your signing secret (which obviously doesn't appear in the static map URL).
 
 
 Google API Daily Limit

--- a/start_pokealarm.py
+++ b/start_pokealarm.py
@@ -509,6 +509,9 @@ def parse_settings(root_path):
         '-k', '--gmaps-key', action='append',
         default=[None], help='Specify a Google API Key to use.')
     parser.add_argument(
+        '--gmaps-signing-secret', action='append',
+        default=[None], help='Specify a Google API Signing Secret')
+    parser.add_argument(
         '--gmaps-rev-geocode', type=parse_boolean, action='append',
         default=[None], help='Enable Walking Distance Matrix DTS.')
     parser.add_argument(
@@ -586,7 +589,7 @@ def parse_settings(root_path):
                 args.timezone, args.gmaps_rev_geocode, args.gmaps_dm_walk,
                 args.gmaps_dm_bike, args.gmaps_dm_drive,
                 args.gmaps_dm_transit, args.mgr_log_lvl, args.mgr_log_size,
-                args.mgr_log_file]:
+                args.mgr_log_file, args.gmaps_signing_secret]:
         if len(arg) > 1:  # Remove defaults from the list
             arg.pop(0)
         size = len(arg)
@@ -628,6 +631,8 @@ def parse_settings(root_path):
             name=args.manager_name[m_ct],
             google_key=get_from_list(
                 args.gmaps_key, m_ct, args.gmaps_key[0]),
+            google_signing_key=get_from_list(
+                args.gmaps_signing_secret, m_ct, args.gmaps_signing_secret[0]),
             locale=get_from_list(args.locale, m_ct, args.locale[0]),
             units=get_from_list(args.units, m_ct, args.units[0]),
             timezone=get_from_list(args.timezone, m_ct, args.timezone[0]),


### PR DESCRIPTION
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->


<!--
 Please make all PRs to the dev branch. The dev branch will be
 periodically pulled into the master branch. This allows time for
 the changes and documentation to be tested before being exposed to
 a wider population.
--->

## Description
<!-- In detail, describe what your PR adds to PokeAlarm -->

This PR adds the ability to generate signed requests when generation the static map URL. I also added documentation to explain how to set it up correctly.

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
<!---
 Why is this change required? What problem does it solve?
 If it fixes an open issue, please link to the issue here.
-->
**The static map of GMaps is currently suffering from a security issue** as it exposes the GMaps API key in static image URLs and anybody who has this key can make his own requests for his application or can even spam requests.

To prevent this, there is something called [digital signature](https://developers.google.com/maps/documentation/maps-static/digital-signature#sample-code-for-url-signing) which allow to generate a signature using:
- the static image URL (which contains the API key)
- a signing secret string which stay secret and never exposed in any way

Once the signing secret is set up, by configuring the API key, we can only allow digitally signed requests and so, even if someone know this API key, it will be useless as it is if the signature cannot be generated to authenticate the request.

By knowing this, this PR introduce the ability to generate signed requests to improve potential malicious uses of your API key.  
**This feature is a non-breaking change for those who will not change their config.** To enable the signed requests, a new parameter in config.ini named `gmaps-signing-secret` has been added and empty by default. If it's not provided, the behaviour will stay the same as before given we can't sign without this secret string. If the secret is provided with the API key, the next requests will be automatically signed.

## How Has This Been Tested?
<!---
 Please describe in detail how you tested your changes. Make sure to
 describe what tests you have performed, your testing environment,
 and if you have used this in a production setting. Please add
 screenshots if appropriate.
-->

Tested on a live configuration and all worked like a charm.

## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change to https://github.com/RocketMap/PokeAlarmWiki.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [x] This change requires an update to the Wiki.
- [ ] This change does not require an update to the Wiki.

Added in this PR.