### PR TITLE
Add custom startup message

### DIFF
--- a/PokeAlarm/Alarms/Discord/DiscordAlarm.py
+++ b/PokeAlarm/Alarms/Discord/DiscordAlarm.py
@@ -125,6 +125,7 @@ class DiscordAlarm(Alarm):
         # Optional Alarm Parameters
         self.__startup_message = parse_boolean(
             settings.pop('startup_message', "True"))
+        self.__startup_text = settings.pop('startup_text', "")
         self.__disable_embed = parse_boolean(
             settings.pop('disable_embed', "False"))
         self.__avatar_url = settings.pop('avatar_url', "")
@@ -166,7 +167,9 @@ class DiscordAlarm(Alarm):
                 'url': self.__webhook_url,
                 'payload': {
                     'username': 'PokeAlarm',
-                    'content': 'PokeAlarm activated!'
+                    'content': ('PokeAlarm activated!'
+                                if self.__startup_text == ""
+                                else self.__startup_text)
                 }
             }
             try_sending(self._log, self.connect, "Discord",

--- a/PokeAlarm/Alarms/FacebookPage/FacebookPageAlarm.py
+++ b/PokeAlarm/Alarms/FacebookPage/FacebookPageAlarm.py
@@ -111,6 +111,7 @@ class FacebookPageAlarm(Alarm):
         # Optional Alarm Parameters
         self.__startup_message = parse_boolean(
             settings.pop('startup_message', "True"))
+        self.__startup_text = settings.pop('startup_text', "")
 
         # Set Alerts
         self.__monsters = self.create_alert_settings(
@@ -144,8 +145,10 @@ class FacebookPageAlarm(Alarm):
     def startup_message(self):
         if self.__startup_message:
             timestamps = get_time_as_str(datetime.utcnow())
-            self.post_to_wall("{} - PokeAlarm has initialized!".format(
-                timestamps[2]))
+            self.post_to_wall(f"{timestamps[2]} - " +
+                              ("PokeAlarm has initialized!"
+                               if self.__startup_text == ""
+                               else self.__startup_text))
             self._log.info("Startup message sent!")
 
     # Set the appropriate settings for each alert

--- a/PokeAlarm/Alarms/Pushbullet/PushBulletAlarm.py
+++ b/PokeAlarm/Alarms/Pushbullet/PushBulletAlarm.py
@@ -77,6 +77,7 @@ class PushbulletAlarm(Alarm):
         # Optional Alarm Parameters
         self.__startup_message = parse_boolean(
             settings.pop('startup_message', "True"))
+        self.__startup_text = settings.pop('startup_text', "")
         self.__channel = settings.pop('channel', "True")
         self.__sender = None
 
@@ -127,7 +128,9 @@ class PushbulletAlarm(Alarm):
             args = {
                 "sender": self.__sender,
                 "title": "PokeAlarm activated!",
-                "message": "PokeAlarm has successully started!"
+                "message": ("PokeAlarm has successully started!"
+                            if self.__startup_text == ""
+                            else self.__startup_text)
             }
             try_sending(
                 self._log, self.connect, "PushBullet", self.push_note, args)

--- a/PokeAlarm/Alarms/Slack/SlackAlarm.py
+++ b/PokeAlarm/Alarms/Slack/SlackAlarm.py
@@ -104,6 +104,7 @@ class SlackAlarm(Alarm):
         # Optional Alarm Parameters
         self.__startup_message = parse_boolean(
             settings.pop('startup_message', "True"))
+        self.__startup_text = settings.pop('startup_text', "")
         self.__map = settings.pop('map', {})
         self.__static_map_key = static_map_key
 
@@ -139,7 +140,9 @@ class SlackAlarm(Alarm):
     def startup_message(self):
         if self.__startup_message:
             self.send_message(self.__default_channel, username="PokeAlarm",
-                              text="PokeAlarm activated!")
+                              text=("PokeAlarm activated!"
+                                    if self.__startup_text == ""
+                                    else self.__startup_text))
             self._log.info("Startup message sent!")
 
     # Set the appropriate settings for each alert

--- a/PokeAlarm/Alarms/Twilio/TwilioAlarm.py
+++ b/PokeAlarm/Alarms/Twilio/TwilioAlarm.py
@@ -74,6 +74,7 @@ class TwilioAlarm(Alarm):
         # Optional Alarm Parameters
         self.__startup_message = parse_boolean(
             settings.pop('startup_message', "True"))
+        self.__startup_text = settings.pop('startup_text', "")
 
         # Optional Alert Parameters
         self.__pokemon = self.set_alert(
@@ -108,7 +109,9 @@ class TwilioAlarm(Alarm):
             self.send_sms(
                 to_num=self.__to_number,
                 from_num=self.__from_number,
-                body="PokeAlarm activated!"
+                body=("PokeAlarm activated!"
+                      if self.__startup_text == ""
+                      else self.__startup_text)
             )
             self._log.info("Startup message sent!")
 

--- a/PokeAlarm/Alarms/Twitter/TwitterAlarm.py
+++ b/PokeAlarm/Alarms/Twitter/TwitterAlarm.py
@@ -78,6 +78,7 @@ class TwitterAlarm(Alarm):
         # Optional Alarm Parameters
         self.__startup_message = parse_boolean(
             settings.pop('startup_message', "True"))
+        self.__startup_text = settings.pop('startup_text', "")
 
         # Optional Alert Parameters
         self.__pokemon = self.create_alert_settings(
@@ -113,7 +114,10 @@ class TwitterAlarm(Alarm):
         if self.__startup_message:
             timestamps = get_time_as_str(datetime.utcnow())
             args = {
-                "status": "{}- PokeAlarm activated!" .format(timestamps[2])
+                "status": (f"{timestamps[2]} - " +
+                           ("PokeAlarm has initialized!"
+                               if self.__startup_text == ""
+                               else self.__startup_text))
             }
             try_sending(
                 self._log, self.connect, "Twitter", self.send_tweet, args)

--- a/docs/configuration/alarms/discord.rst
+++ b/docs/configuration/alarms/discord.rst
@@ -102,6 +102,7 @@ These optional parameters are entered at the same level as ``"type":"discord"``.
 ================= ============================================== =========
 Parameters        Description                                    Default
 `startup_message` Confirmation post when PokeAlarm initialized   ``true``
+`startup_text`    Custom message post when PA initialized        
 `disable_embed`   Remove embed from message                      ``false``
 ================= ============================================== =========
 

--- a/docs/configuration/alarms/facebook-pages.rst
+++ b/docs/configuration/alarms/facebook-pages.rst
@@ -80,11 +80,13 @@ functional alarm layout for Facebook Pages.
 
 These optional parameters are entered at the same level as ``"type":"facebook_page"``.
 
-+-------------------+-----------------------------------------------+----------+
-| Parameters        | Description                                   | Default  |
-+-------------------+-----------------------------------------------+----------+
-| `startup_message` | Confirmation post when PokeAlarm initialized  | ``true`` |
-+-------------------+-----------------------------------------------+----------+
++-------------------+----------------------------------------------+----------+
+| Parameters        | Description                                  | Default  |
++-------------------+----------------------------------------------+----------+
+| `startup_message` | Confirmation post when PokeAlarm initialized | ``true`` |
++-------------------+----------------------------------------------+----------+
+| `startup_text`    | Custom message post when PA initialized      |          |
++-------------------+----------------------------------------------+----------+
 
 These optional parameters below are applicable to the ``monsters``, ``stops``,
 ``gyms``, ``eggs``, and ``raids`` sections of the JSON file. Check Image column to

--- a/docs/configuration/alarms/pushbullet.rst
+++ b/docs/configuration/alarms/pushbullet.rst
@@ -78,11 +78,13 @@ functional alarm layout.
 
 These optional parameters are entered at the same level as ``"type":"pushbullet"``.
 
-+-------------------+-----------------------------------------------+----------+
-| Parameters        | Description                                   | Default  |
-+-------------------+-----------------------------------------------+----------+
-| `startup_message` | Confirmation post when PokeAlarm initialized  | ``true`` |
-+-------------------+-----------------------------------------------+----------+
++-------------------+----------------------------------------------+----------+
+| Parameters        | Description                                  | Default  |
++-------------------+----------------------------------------------+----------+
+| `startup_message` | Confirmation post when PokeAlarm initialized | ``true`` |
++-------------------+----------------------------------------------+----------+
+| `startup_text`    | Custom message post when PA initialized      |          |
++-------------------+----------------------------------------------+----------+
 
 These optional parameters below are applicable to the ``monsters``, ``stops``,
 ``gyms``, ``eggs``, and ``raids`` sections of the JSON file.

--- a/docs/configuration/alarms/slack.rst
+++ b/docs/configuration/alarms/slack.rst
@@ -88,11 +88,13 @@ alarm layout for Slack.
 
 These optional parameters are entered at the same level as ``"type":"slack"``.
 
-+-------------------+-----------------------------------------------+----------+
-| Parameters        | Description                                   | Default  |
-+-------------------+-----------------------------------------------+----------+
-| `startup_message` | Confirmation post when PokeAlarm initialized  | ``true`` |
-+-------------------+-----------------------------------------------+----------+
++-------------------+----------------------------------------------+----------+
+| Parameters        | Description                                  | Default  |
++-------------------+----------------------------------------------+----------+
+| `startup_message` | Confirmation post when PokeAlarm initialized | ``true`` |
++-------------------+----------------------------------------------+----------+
+| `startup_text`    | Custom message post when PA initialized      |          |
++-------------------+----------------------------------------------+----------+
 
 These optional parameters below are applicable to the ``monsters``, ``stops``,
 ``gyms``, ``eggs``, and ``raids`` sections of the JSON file.

--- a/docs/configuration/alarms/telegram.rst
+++ b/docs/configuration/alarms/telegram.rst
@@ -102,6 +102,7 @@ Parameters        Description                                            Default
 `max_attempts`    Max attempts to send for each message.                 ``"3"``
 `web_preview`     Enables web preview for links in message.              ``false``
 `startup_message` Confirmation post when PokeAlarm initialized           ``true``
+`startup_text`    Custom message post when PA initialized                
 ================= ====================================================== ============
 
 These optional parameters below are applicable to the ``monsters``, ``stops``,

--- a/docs/configuration/alarms/twilio.rst
+++ b/docs/configuration/alarms/twilio.rst
@@ -102,6 +102,28 @@ alarm configuration.
 Optional Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Startup parameters
+..................
+
+In addition to the required parameters, several ``alarms.json`` optional
+parameters are available to personalize your notifications. Below is an
+example of these optional parameters and how they are incorporated into a
+functional alarm layout.
+
+These optional parameters are entered at the same level as ``"type":"twilio"``.
+
++-------------------+----------------------------------------------+----------+
+| Parameters        | Description                                  | Default  |
++-------------------+----------------------------------------------+----------+
+| `startup_message` | Confirmation post when PokeAlarm initialized | ``true`` |
++-------------------+----------------------------------------------+----------+
+| `startup_text`    | Custom message post when PA initialized      |          |
++-------------------+----------------------------------------------+----------+
+
+
+Event parameters
+................
+
 These optional parameters below are applicable to the ``monsters``, ``stops``,
 ``gyms``, ``eggs``, and ``raids`` sections of the JSON file.
 

--- a/docs/configuration/alarms/twitter.rst
+++ b/docs/configuration/alarms/twitter.rst
@@ -85,11 +85,13 @@ functional alarm layout.
 
 These optional parameters are entered at the same level as ``"type":"twitter"``.
 
-+-------------------+-----------------------------------------------+----------+
-| Parameters        | Description                                   | Default  |
-+-------------------+-----------------------------------------------+----------+
-| `startup_message` | Confirmation post when PokeAlarm initialized  | ``true`` |
-+-------------------+-----------------------------------------------+----------+
++-------------------+----------------------------------------------+----------+
+| Parameters        | Description                                  | Default  |
++-------------------+----------------------------------------------+----------+
+| `startup_message` | Confirmation post when PokeAlarm initialized | ``true`` |
++-------------------+----------------------------------------------+----------+
+| `startup_text`    | Custom message post when PA initialized      |          |
++-------------------+----------------------------------------------+----------+
 
 These optional parameters below are applicable to the ``monsters``, ``stops``,
 ``gyms``, ``eggs``, and ``raids`` sections of the JSON file.


### PR DESCRIPTION
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->


<!--
 Please make all PRs to the dev branch. The dev branch will be
 periodically pulled into the master branch. This allows time for
 the changes and documentation to be tested before being exposed to
 a wider population.
--->

## Description
<!-- In detail, describe what your PR adds to PokeAlarm -->
Add a new parameter called `startup_text` to customize the startup message when PA initialized.

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
<!---
 Why is this change required? What problem does it solve?
 If it fixes an open issue, please link to the issue here.
-->
Asked by someone and resolves #574.
I think it can be a good feature. This will allow us to mention Discord users that an alarm has been activated or simply to translate the startup message in one's own language.

## How Has This Been Tested?
<!---
 Please describe in detail how you tested your changes. Make sure to
 describe what tests you have performed, your testing environment,
 and if you have used this in a production setting. Please add
 screenshots if appropriate.
-->
Tested on Discord as I only use this alarm type.
It's a small change enough to be safe without confirmations from all alarm types.

## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change to https://github.com/RocketMap/PokeAlarmWiki.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [x] This change requires an update to the Wiki.
- [ ] This change does not require an update to the Wiki.

Included in this PR.