### PR TITLE
Pin jinja2 and werkzeug package versions to resolve conflicts with Flask

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ pytz==2019.3
 portalocker==1.5.2
 requests==2.22.0
 greenlet==0.4.13
+jinja2==3.0.3
 itsdangerous==2.0.1; python_version >= '3'
 itsdangerous==1.1.0; python_version < '3'

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ portalocker==1.5.2
 requests==2.22.0
 greenlet==0.4.13
 jinja2==3.0.3
+werkzeug==2.0.3
 itsdangerous==2.0.1; python_version >= '3'
 itsdangerous==1.1.0; python_version < '3'


### PR DESCRIPTION
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->


<!--
 Please make all PRs to the dev branch. The dev branch will be
 periodically pulled into the master branch. This allows time for
 the changes and documentation to be tested before being exposed to
 a wider population.
--->

## Description
<!-- In detail, describe what your PR adds to PokeAlarm -->
Pin Jinja2 Python package to v3.0.3
Pin Werkzeug Python package to v2.0.3

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
<!---
 Why is this change required? What problem does it solve?
 If it fixes an open issue, please link to the issue here.
-->
As mentioned by #827, Jinja2 > v3.0.3 is incompatible with Flask  v1.x.x (currently pinned to 1.1.1).
Werkzeug > v2.0.3 is also incompatible with Flask  v1.x.x.
Resolves #827