### PR TITLE
Weather update

### DIFF
--- a/PokeAlarm/Events/BaseEvent.py
+++ b/PokeAlarm/Events/BaseEvent.py
@@ -18,6 +18,10 @@ class BaseEvent(object):
         # Create an id for this event to be recognized as
         self.id = time.time()
 
+    def update_with_cache(self, cache):
+        """ Update event infos using cached data from previous events. """
+        raise NotImplementedError("This is an abstract method.")
+
     def generate_dts(self, locale, timezone, units):
         """ Return a dict with all the DTS for this event. """
         raise NotImplementedError("This is an abstract method.")

--- a/PokeAlarm/Events/EggEvent.py
+++ b/PokeAlarm/Events/EggEvent.py
@@ -63,6 +63,12 @@ class EggEvent(BaseEvent):
         self.geofence = Unknown.REGULAR
         self.custom_dts = {}
 
+    def update_with_cache(self, cache):
+        """ Update event infos using cached data from previous events. """
+
+        # Nothing to update
+        pass
+
     def generate_dts(self, locale, timezone, units):
         """ Return a dict with all the DTS for this event. """
         hatch_time = get_time_as_str(self.hatch_time, timezone)

--- a/PokeAlarm/Events/GruntEvent.py
+++ b/PokeAlarm/Events/GruntEvent.py
@@ -110,10 +110,10 @@ class GruntEvent(BaseEvent):
             'stop_image': self.stop_image,
             'grunt_id': self.grunt_type_id,
             'grunt_id_3': f'{self.grunt_type_id:03}',
+            'grunt_name': self.grunt_name,
             'type_name': locale.get_type_name(self.mon_type_id),
             'type_emoji': get_type_emoji(self.mon_type_id),
             'gender_id': self.gender_id,
-            'grunt_name': self.grunt_name,
             'gender': self.gender,
 
             # Rewards

--- a/PokeAlarm/Events/GymEvent.py
+++ b/PokeAlarm/Events/GymEvent.py
@@ -51,6 +51,12 @@ class GymEvent(BaseEvent):
         self.geofence = Unknown.REGULAR
         self.custom_dts = {}
 
+    def update_with_cache(self, cache):
+        """ Update event infos using cached data from previous events. """
+
+        # Nothing to update
+        pass
+
     def generate_dts(self, locale, timezone, units):
         """ Return a dict with all the DTS for this event. """
         dts = self.custom_dts.copy()

--- a/PokeAlarm/Events/MonEvent.py
+++ b/PokeAlarm/Events/MonEvent.py
@@ -54,11 +54,8 @@ class MonEvent(BaseEvent):
         self.direction = Unknown.TINY  # Completed by Manager
 
         # Weather Infos
-        # TODO: remove 'boosted_weather' and 'weather_boosted_condition' once
-        # all the scanners migrate to 'weather'
         self.weather_id = check_for_none(
-            int, (data.get('weather') or data.get('boosted_weather') or
-                  data.get('weather_boosted_condition')), Unknown.TINY)
+            int, data.get('weather'), Unknown.TINY)
         self.boosted_weather_id = \
             0 if Unknown.is_not(self.weather_id) else Unknown.TINY
         if is_weather_boosted(self.weather_id, self.monster_id, self.form_id):

--- a/PokeAlarm/Events/MonEvent.py
+++ b/PokeAlarm/Events/MonEvent.py
@@ -12,7 +12,7 @@ from PokeAlarm.Utils import (
     get_applemaps_link, get_shiny_emoji, get_time_as_str,
     get_seconds_remaining, get_base_types, get_dist_as_str,
     get_weather_emoji, get_spawn_verified_emoji, get_type_emoji,
-    get_waze_link, get_gender_sym)
+    get_waze_link, get_gender_sym, is_weather_boosted)
 from . import BaseEvent
 from PokeAlarm.Utilities import MonUtils
 
@@ -52,10 +52,12 @@ class MonEvent(BaseEvent):
         self.distance = Unknown.SMALL  # Completed by Manager
         self.direction = Unknown.TINY  # Completed by Manager
         self.weather_id = check_for_none(
-            int, data.get('weather'), Unknown.TINY)
-        self.boosted_weather_id = check_for_none(
-            int, data.get('boosted_weather')
-            or data.get('weather_boosted_condition'), 0)
+            int, (data.get('weather') or data.get('boosted_weather') or
+                  data.get('weather_boosted_condition')), Unknown.TINY)
+        self.boosted_weather_id = \
+            0 if Unknown.is_not(self.weather_id) else Unknown.TINY
+        if is_weather_boosted(self.weather_id, self.monster_id, self.form_id):
+            self.boosted_weather_id = self.weather_id
 
         # Encounter Stats
         self.mon_lvl = check_for_none(

--- a/PokeAlarm/Events/QuestEvent.py
+++ b/PokeAlarm/Events/QuestEvent.py
@@ -70,6 +70,12 @@ class QuestEvent(BaseEvent):
         self.item_type = data.get('item_type')
         self.item_id = data.get('item_id', 0)
 
+    def update_with_cache(self, cache):
+        """ Update event infos using cached data from previous events. """
+
+        # Nothing to update
+        pass
+
     def generate_dts(self, locale, timezone, units):
         """ Return a dict with all the DTS for this event. """
         form_name = locale.get_form_name(self.monster_id, self.monster_form_id)

--- a/PokeAlarm/Events/RaidEvent.py
+++ b/PokeAlarm/Events/RaidEvent.py
@@ -9,9 +9,13 @@ from PokeAlarm.Utils import get_gmaps_link, get_applemaps_link, \
     get_move_duration, get_move_energy, get_seconds_remaining, \
     get_dist_as_str, get_pokemon_cp_range, is_weather_boosted, \
     get_base_types, get_weather_emoji, get_type_emoji, get_waze_link, \
+<<<<<<< HEAD
     get_team_emoji, get_ex_eligible_emoji, get_shiny_emoji, \
     get_gender_sym
 from PokeAlarm.Utilities import MonUtils
+=======
+    get_team_emoji, get_ex_eligible_emoji, get_cached_weather_id_from_coord
+>>>>>>> introduce cache use to update event infos
 
 
 class RaidEvent(BaseEvent):
@@ -103,6 +107,21 @@ class RaidEvent(BaseEvent):
         self.name = self.gym_id
         self.geofence = Unknown.REGULAR
         self.custom_dts = {}
+
+    def update_with_cache(self, cache):
+        """ Update event infos using cached data from previous events. """
+
+        # Update weather
+        weather_id = get_cached_weather_id_from_coord(
+            self.lat, self.lng, cache)
+        if Unknown.is_not(weather_id):
+            self.weather_id = BaseEvent.check_for_none(
+                int, weather_id, Unknown.TINY)
+            self.boosted_weather_id = \
+                0 if Unknown.is_not(self.weather_id) else Unknown.TINY
+            if is_weather_boosted(self.weather_id, self.mon_id, self.form_id):
+                self.boosted_weather_id = self.weather_id
+                self.boss_level = 25
 
     def generate_dts(self, locale, timezone, units):
         """ Return a dict with all the DTS for this event. """

--- a/PokeAlarm/Events/RaidEvent.py
+++ b/PokeAlarm/Events/RaidEvent.py
@@ -9,13 +9,9 @@ from PokeAlarm.Utils import get_gmaps_link, get_applemaps_link, \
     get_move_duration, get_move_energy, get_seconds_remaining, \
     get_dist_as_str, get_pokemon_cp_range, is_weather_boosted, \
     get_base_types, get_weather_emoji, get_type_emoji, get_waze_link, \
-<<<<<<< HEAD
     get_team_emoji, get_ex_eligible_emoji, get_shiny_emoji, \
-    get_gender_sym
+    get_gender_sym, get_cached_weather_id_from_coord
 from PokeAlarm.Utilities import MonUtils
-=======
-    get_team_emoji, get_ex_eligible_emoji, get_cached_weather_id_from_coord
->>>>>>> introduce cache use to update event infos
 
 
 class RaidEvent(BaseEvent):

--- a/PokeAlarm/Events/StopEvent.py
+++ b/PokeAlarm/Events/StopEvent.py
@@ -48,6 +48,12 @@ class StopEvent(BaseEvent):
         self.geofence = Unknown.REGULAR
         self.custom_dts = {}
 
+    def update_with_cache(self, cache):
+        """ Update event infos using cached data from previous events. """
+
+        # Nothing to update
+        pass
+
     def generate_dts(self, locale, timezone, units):
         """ Return a dict with all the DTS for this event. """
         time = get_time_as_str(self.expiration, timezone)

--- a/PokeAlarm/Events/WeatherEvent.py
+++ b/PokeAlarm/Events/WeatherEvent.py
@@ -36,6 +36,12 @@ class WeatherEvent(BaseEvent):
         self.geofence = Unknown.REGULAR
         self.custom_dts = {}
 
+    def update_with_cache(self, cache):
+        """ Update event infos using cached data from previous events. """
+
+        # Nothing to update
+        pass
+
     def generate_dts(self, locale, timezone, units):
         """ Return a dict with all the DTS for this event. """
         weather_name = locale.get_weather_name(self.weather_id)

--- a/PokeAlarm/Filters/GruntFilter.py
+++ b/PokeAlarm/Filters/GruntFilter.py
@@ -70,6 +70,19 @@ class GruntFilter(BaseFilter):
             event_attribute='time_left', eval_func=operator.ge,
             limit=BaseFilter.parse_as_type(int, 'max_time_left', data))
 
+        # Weather
+        # self.weather_ids = self.evaluate_attribute(
+        #    event_attribute='weather_id', eval_func=operator.contains,
+        #    limit=BaseFilter.parse_as_set(get_weather_id, 'weather', data))
+        # self.boosted_weather_ids = self.evaluate_attribute(
+        #    event_attribute='boosted_weather_id', eval_func=operator.contains,
+        #    limit=BaseFilter.parse_as_set(
+        #        get_weather_id, 'boosted_weather', data))
+        # self.boosted_weather = self.evaluate_attribute(
+        #    event_attribute='boosted_weather_id',
+        #    eval_func=weather_id_is_boosted,
+        #    limit=BaseFilter.parse_as_type(bool, 'is_boosted_weather', data))
+
         # Geofences
         self.geofences = self.evaluate_geofences(
             geofences=BaseFilter.parse_as_list(str, 'geofences', data),

--- a/PokeAlarm/Filters/GruntFilter.py
+++ b/PokeAlarm/Filters/GruntFilter.py
@@ -4,7 +4,8 @@ import operator
 # Local Imports
 from . import BaseFilter
 from PokeAlarm.Utilities import MonUtils
-from PokeAlarm.Utils import get_gender_sym, match_items_in_array
+from PokeAlarm.Utils import get_gender_sym, match_items_in_array, \
+    get_weather_id, weather_id_is_boosted
 
 
 class GruntFilter(BaseFilter):
@@ -71,17 +72,17 @@ class GruntFilter(BaseFilter):
             limit=BaseFilter.parse_as_type(int, 'max_time_left', data))
 
         # Weather
-        # self.weather_ids = self.evaluate_attribute(
-        #    event_attribute='weather_id', eval_func=operator.contains,
-        #    limit=BaseFilter.parse_as_set(get_weather_id, 'weather', data))
-        # self.boosted_weather_ids = self.evaluate_attribute(
-        #    event_attribute='boosted_weather_id', eval_func=operator.contains,
-        #    limit=BaseFilter.parse_as_set(
-        #        get_weather_id, 'boosted_weather', data))
-        # self.boosted_weather = self.evaluate_attribute(
-        #    event_attribute='boosted_weather_id',
-        #    eval_func=weather_id_is_boosted,
-        #    limit=BaseFilter.parse_as_type(bool, 'is_boosted_weather', data))
+        self.weather_ids = self.evaluate_attribute(
+            event_attribute='weather_id', eval_func=operator.contains,
+            limit=BaseFilter.parse_as_set(get_weather_id, 'weather', data))
+        self.boosted_weather_ids = self.evaluate_attribute(
+            event_attribute='boosted_weather_id', eval_func=operator.contains,
+            limit=BaseFilter.parse_as_set(
+                get_weather_id, 'boosted_weather', data))
+        self.boosted_weather = self.evaluate_attribute(
+            event_attribute='boosted_weather_id',
+            eval_func=weather_id_is_boosted,
+            limit=BaseFilter.parse_as_type(bool, 'is_boosted_weather', data))
 
         # Geofences
         self.geofences = self.evaluate_geofences(

--- a/PokeAlarm/Utils.py
+++ b/PokeAlarm/Utils.py
@@ -8,6 +8,7 @@ from math import radians, sin, cos, atan2, sqrt, degrees
 import os
 import sys
 # 3rd Party Imports
+from s2cell import s2cell
 # Local Imports
 from PokeAlarm import not_so_secret_url
 from PokeAlarm import config
@@ -671,8 +672,8 @@ def get_xl_candy_costs():
     return get_stardust_costs.info.get('xl_candy')
 
 
-# Return a boolean for whether the raid boss will have it's catch CP boosted
-def is_weather_boosted(weather_id, pokemon_id, form_id=0):
+# Return a boolean for whether the monster or the type is weather boosted
+def is_weather_boosted(weather_id, pokemon_id=0, form_id=0, mon_type=None):
     if not hasattr(is_weather_boosted, 'info'):
         is_weather_boosted.info = {}
         file_ = get_path('data/weather_boosts.json')
@@ -683,9 +684,11 @@ def is_weather_boosted(weather_id, pokemon_id, form_id=0):
             is_weather_boosted.info[w_id] = j[w_id]
 
     boosted_types = is_weather_boosted.info.get(str(weather_id), {})
-    types = get_base_types(pokemon_id, form_id)
-
-    return types[0] in boosted_types or types[1] in boosted_types
+    if mon_type is None:
+        types = get_base_types(pokemon_id, form_id)
+        return types[0] in boosted_types or types[1] in boosted_types
+    else:
+        return mon_type in boosted_types
 
 
 def weather_id_is_boosted(desired_status, weather_id):
@@ -939,6 +942,12 @@ def get_weather_id(weather_name):
     except ValueError:
         raise ValueError("Unable to interpret `{}` as a valid "
                          " weather name or id.".format(weather_name))
+
+
+# Returns the id of the cached weather from (lat,lng)
+def get_cached_weather_id_from_coord(lat, lng, cache):
+    cell_id = s2cell.lat_lon_to_cell_id(lat, lng, 10)
+    return cache.cell_weather_id(str(cell_id))
 
 
 # Returns true if any item is in the provided list

--- a/docs/configuration/events/invasion-events.rst
+++ b/docs/configuration/events/invasion-events.rst
@@ -96,3 +96,25 @@ time_left_raw_hours   Hours only until the lure expires.                        
 time_left_raw_minutes Minutes only until the lure expires.                                15
 time_left_raw_seconds Seconds only until the lure expires.                                52
 ===================== =================================================================== ===========
+
+Weather
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+======================== =======================================================
+DTS                      Description
+======================== =======================================================
+weather_id               Weather ID of the shadow monster.
+weather                  Weather name of the shadow monster.
+weather_or_empty         Weather name of the shadow monster, or empty string if
+                         unknown.
+weather_emoji            Weather emoji of the shadow monster, or empty string if
+                         unknown.
+boosted_weather_id       Return weather ID if shadow monster is boosted.
+boosted_weather          Return weather name if shadow monster is boosted.
+boosted_weather_or_empty Return weather name if shadow monster is boosted, or
+                         empty string if unknown.
+boosted_weather_emoji    Return weather emoji if shadow monster is boosted, or
+                         empty string if unknown.
+boosted_or_empty         Return `boosted` if shadow monster is boosted, or empty
+                         string if not.
+======================== =======================================================

--- a/docs/configuration/filters/invasion-filters.rst
+++ b/docs/configuration/filters/invasion-filters.rst
@@ -62,6 +62,9 @@ max_dist            Max distance of event from set location in miles            
                     or meters (depending on settings).
 min_time_left       Minimum time (in seconds) until monster despawns.                ``1000``
 max_time_left       Maximum time (in seconds) until monster despawns.                ``2400``
+weather             Accepted weather conditions, by id or name.                      ``["Clear",2]``
+boosted_weather     Accepted boosted weather conditions, by id or name.               ``["Clear",2]``
+is_boosted_weather  Accepts or denies based on boosted weather conditions.           ``true``
 geofences           See :ref:`geofences_filters` page on 'Geofences'                 ``["geofence1","geofence2"]``
 exclude_geofences   Opposite of `geofences`. See :ref:`geofences_filters` page.      ``["geofence1","geofence2"]``
 min_time            See :ref:`time_dts_filters` page on 'Time DTS'                   ``8:30``

--- a/docs/configuration/filters/monster-filters.rst
+++ b/docs/configuration/filters/monster-filters.rst
@@ -125,7 +125,7 @@ max_dist           Max distance of event from set location in miles       ``1000
 min_time_left      Minimum time (in seconds) until monster despawns.      ``1000``
 max_time_left      Maximum time (in seconds) until monster despawns.      ``2400``
 weather            Accepted weather conditions, by id or name.            ``["Clear",2]``
-boosted_weather    Accepted boosted weather condition, by id or name.     ``["Clear",2]``
+boosted_weather    Accepted boosted weather conditions, by id or name.     ``["Clear",2]``
 is_boosted_weather Accepts or denies based on boosted weather conditions. ``true``
 geofences          See :ref:`geofences_filters` page on 'Geofences'       ``["geofence1","geofence2"]``
 min_time           See :ref:`time_dts_filters` page on 'Time DTS'         ``8:30``

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ requests==2.22.0
 greenlet==0.4.13
 jinja2==3.0.3; python_version >= '3'
 werkzeug==2.0.3; python_version >= '3'
+s2cell==1.6.0
 itsdangerous==2.0.1; python_version >= '3'
 jinja2==2.11.3; python_version < '3'
 werkzeug==1.0.1; python_version < '3'

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ requests==2.22.0
 greenlet==0.4.13
 jinja2==3.0.3; python_version >= '3'
 werkzeug==2.0.3; python_version >= '3'
-s2cell==1.6.0
+s2cell==1.5.0; python_version >= '3'
 itsdangerous==2.0.1; python_version >= '3'
 jinja2==2.11.3; python_version < '3'
 werkzeug==1.0.1; python_version < '3'

--- a/tests/filters/test_monster_filter.py
+++ b/tests/filters/test_monster_filter.py
@@ -278,23 +278,23 @@ class TestMonsterFilter(unittest.TestCase):
     @generic_filter_test
     def test_weather(self):
         self.filt = {'weather': [1, "windy"]}
-        self.event_key = "weather"
+        self.event_key = 'weather'
         self.pass_vals = [1, 5]
         self.fail_vals = [0, 2, 8]
 
     @generic_filter_test
     def test_boosted_weather(self):
-        self.filt = {'boosted_weather': [1, 'windy']}
-        self.event_key = 'boosted_weather'
-        self.pass_vals = [1, 5]
+        self.filt = {'boosted_weather': [1, 'cloudy']}
+        self.event_key = 'weather'
+        self.pass_vals = [1, 4]
         self.fail_vals = [0, 2, 8]
 
     @generic_filter_test
     def test_is_boosted_weather(self):
         self.filt = {'is_boosted_weather': True}
-        self.event_key = 'boosted_weather'
-        self.pass_vals = [1, 2, 5]
-        self.fail_vals = [0]
+        self.event_key = 'weather'
+        self.pass_vals = [1, 4]
+        self.fail_vals = [0, 2, 8]
 
     @generic_filter_test
     def test_types(self):

--- a/tools/webhook_test.py
+++ b/tools/webhook_test.py
@@ -101,8 +101,7 @@ def set_init(webhook_type):
                 "spawn_start": 2153,
                 "spawn_end": 3264,
                 "verified": False,
-                "weather": None,
-                "boosted_weather": None
+                "weather": None
             }
         }
     elif webhook_type == whtypes["2"]:
@@ -508,9 +507,6 @@ if type == whtypes["1"]:
     print("Weather type (default: 0)")
     print(weather_formatted, end='\n> ')
     int_or_default('weather')
-    print("Pokemon weather boosted? (y/n)", end='\n> ')
-    if input() in truthy:
-        payload["message"]["boosted_weather"] = payload["message"]["weather"]
 elif type == whtypes["2"]:
     stop_info('pokestop_id', 'url', 'name')
     print("Lure type (default: 501)")


### PR DESCRIPTION
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->


<!--
 Please make all PRs to the dev branch. The dev branch will be
 periodically pulled into the master branch. This allows time for
 the changes and documentation to be tested before being exposed to
 a wider population.
--->

## Description
<!-- In detail, describe what your PR adds to PokeAlarm -->
These changes bring a lot of fixes related to the weather.

- Weather boost conditions are now fully determined by the weather ID received from the scanners as they only send current weather. Weather boost is now automatically calculated and not set from webhook as they don't contain this info. The monster form update still brought the necessary tools to determine if a special monster is boosted or no.

- Cached monsters now take the current weather into consideration. This means if a monster is weather boosted at 8:50 but lose his boost at 9:00 due to weather changes, the stats change of the monster change and the scanner can send again this monster. As its ID doesn't change with the weather, previously it was rejected by PokeAlarm even if its stats changed, now PokeAlarm process it. Fixes https://github.com/pokealarm/pokealarm/issues/754

- Due to weather boost calculation fixes (1st point), weather filters now work correctly for monster events. Fixes https://github.com/pokealarm/pokealarm/issues/696

- A new system has been added : THE USE OF CACHED DATA! This means that PokeAlarm is now able to determine if a raid is weather boosted when it just hatches, same for a monster spawning or a new invasion detected.

- With the recent addition of the DTS and filters for grunt/invasions and the introduction of the use of cache system, it's now possible to filter and know with new DTS if shadow monsters are boosted or no. As a reminder, a boosted monster (normal or shadow) is 4/4/4 guaranteed, which allow players to track godd shadow monsters more easily. Closes https://github.com/pokealarm/pokealarm/issues/731

New DTS for invasions :
- `weather_id`: Weather ID of the shadow monster.
- `weather`: Weather name of the shadow monster.
- `weather_or_empty`: Weather name of the shadow monster, or empty string if unknown.
- `weather_emoji`: Weather emoji of the shadow monster, or empty string if unknown.
- `boosted_weather_id`: Return weather ID if shadow monster is boosted.
- `boosted_weather`: Return weather name if shadow monster is boosted.
- `boosted_weather_or_empty`: Return weather name if shadow monster is boosted, or empty string if unknown.
- `boosted_weather_emoji`: Return weather emoji if shadow monster is boosted, or empty string if unknown.
- `boosted_or_empty`: Return `boosted` if shadow monster is boosted, or empty string if not.

New filters for invasions :
- `weather`: Accepted weather conditions, by id or name.
- `boosted_weather`: Accepted boosted weather conditions, by id or name.
- `is_boosted_weather`: Accepts or denies based on boosted weather conditions.


## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)


## Motivation and Context
<!---
 Why is this change required? What problem does it solve?
 If it fixes an open issue, please link to the issue here.
-->
Weather was broken and unreliable.


## How Has This Been Tested?
<!---
 Please describe in detail how you tested your changes. Make sure to
 describe what tests you have performed, your testing environment,
 and if you have used this in a production setting. Please add
 screenshots if appropriate.
-->
My own branch 'beta' still include this PR and I use it for almost 2 months. Someone also used it to fix these weather issues and reported this worked. I also tested this PR itself during 1 day and nothing wrong to report.


## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change in doc/*.rst files.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [x] This change includes an update to the Wiki.
- [ ] This change requires an update to the Wiki.
- [ ] This change does not require an update to the Wiki.