### PR TITLE
Ignore unreleased generations when listing mon evolutions

### DIFF
--- a/PokeAlarm/Utils.py
+++ b/PokeAlarm/Utils.py
@@ -330,37 +330,40 @@ def get_evolution_chain(j, id_, form_id_, a=None, evolution_details=None):
             pass
         else:
             for evo_id in j[id_].get('forms').get(form_id_).get('evolutions'):
-                if evolution_details:
-                    evo_form_id = j[id_].get('forms').get(form_id_).get(
-                        'evolutions').get(evo_id).get('form')
-                    a.append(f"{evo_id}_{evo_form_id}")
-                else:
-                    a.append(int(evo_id))
-                get_evolution_chain(
-                    j,
-                    str(j[id_].get('forms').get(form_id_).get(
-                        'evolutions').get(evo_id).get('pokemon')),
-                    str(j[id_].get('forms').get(form_id_).get(
-                        'evolutions').get(evo_id).get('form')),
-                    a,
-                    evolution_details)
+                if int(evo_id) <= 898:  # block unreleased generations
+                    if evolution_details:
+                        evo_form_id = j[id_].get('forms').get(form_id_).get(
+                            'evolutions').get(evo_id).get('form')
+                        a.append(f"{evo_id}_{evo_form_id}")
+                    else:
+                        a.append(int(evo_id))
+                    get_evolution_chain(
+                        j,
+                        str(j[id_].get('forms').get(form_id_).get(
+                            'evolutions').get(evo_id).get('pokemon')),
+                        str(j[id_].get('forms').get(form_id_).get(
+                            'evolutions').get(evo_id).get('form')),
+                        a,
+                        evolution_details)
     else:
         if j[id_].get('evolutions') is None:
             pass
         else:
             for evo_id in j[id_].get('evolutions'):
-                if evolution_details:
-                    evo_form_id = j[id_].get(
-                        'evolutions').get(evo_id).get('form')
-                    a.append(f"{evo_id}_{evo_form_id}")
-                else:
-                    a.append(int(evo_id))
-                get_evolution_chain(
-                    j,
-                    str(j[id_].get('evolutions').get(evo_id).get('pokemon')),
-                    "0",
-                    a,
-                    evolution_details)
+                if int(evo_id) <= 898:  # block unreleased generations
+                    if evolution_details:
+                        evo_form_id = j[id_].get(
+                            'evolutions').get(evo_id).get('form')
+                        a.append(f"{evo_id}_{evo_form_id}")
+                    else:
+                        a.append(int(evo_id))
+                    get_evolution_chain(
+                        j,
+                        str(j[id_].get('evolutions').get(
+                            evo_id).get('pokemon')),
+                        "0",
+                        a,
+                        evolution_details)
     return a
 
 
@@ -404,28 +407,34 @@ def get_evolution_cost_chain(j, id_, form_id_, a=None):
             pass
         else:
             for evo_id in j[id_].get('forms').get(form_id_).get('evolutions'):
-                a.append(int(j[id_].get('forms').get(form_id_).get(
-                    'evolutions').get(evo_id).get('candyCost')))
-                get_evolution_cost_chain(
-                    j,
-                    str(j[id_].get('forms').get(form_id_).get(
-                        'evolutions').get(evo_id).get('pokemon')),
-                    str(j[id_].get('forms').get(form_id_).get(
-                        'evolutions').get(evo_id).get('form')),
-                    a)
+
+                candy_cost = int(j[id_].get('forms').get(form_id_).get(
+                    'evolutions').get(evo_id).get('candyCost', 0))
+                if candy_cost != 0:  # block unreleased generations
+                    a.append(int(j[id_].get('forms').get(form_id_).get(
+                        'evolutions').get(evo_id).get('candyCost')))
+                    get_evolution_cost_chain(
+                        j,
+                        str(j[id_].get('forms').get(form_id_).get(
+                            'evolutions').get(evo_id).get('pokemon')),
+                        str(j[id_].get('forms').get(form_id_).get(
+                            'evolutions').get(evo_id).get('form')),
+                        a)
     else:
         if j[id_].get('evolutions') is None:
             pass
         else:
             for evo_id in j[id_].get('evolutions'):
-                a.append(
-                    int((j[id_].get('evolutions').get(
-                        evo_id).get('candyCost', 0))))
-                get_evolution_cost_chain(
-                    j,
-                    str(j[id_].get('evolutions').get(evo_id).get('pokemon')),
-                    "0",
-                    a)
+                candy_cost = int((j[id_].get('evolutions').get(
+                    evo_id).get('candyCost', 0)))
+                if candy_cost != 0:  # block unreleased generations
+                    a.append(candy_cost)
+                    get_evolution_cost_chain(
+                        j,
+                        str(j[id_].get('evolutions').get(
+                            evo_id).get('pokemon')),
+                        "0",
+                        a)
     return a
 
 


### PR DESCRIPTION
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->


<!--
 Please make all PRs to the dev branch. The dev branch will be
 periodically pulled into the master branch. This allows time for
 the changes and documentation to be tested before being exposed to
 a wider population.
--->

## Description
<!-- In detail, describe what your PR adds to PokeAlarm -->

The [remote data file](https://raw.githubusercontent.com/WatWowMap/Masterfile-Generator/master/master-latest-everything.json) used by PokeAlarm added evolutions from the new 2022 generation while there is no data for these monsters in the game.

The function listing evolutions and evolution costs were affected. They now ignore unreleased generations to avoid unknown values.

These pokemons have an evolution from the new 2022 gen and caused crashes:

```
Scyther 123 -> 900
Qwilfish 211 -> 904
Sneasel 215 -> 903
Ursaring 217 -> 901
Stantler 234 -> 899
Basculin 550 -> 902
```

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
<!---
 Why is this change required? What problem does it solve?
 If it fixes an open issue, please link to the issue here.
-->

Fixes https://github.com/pokealarm/pokealarm/issues/839
More information can be found on this issue.

## How Has This Been Tested?
<!---
 Please describe in detail how you tested your changes. Make sure to
 describe what tests you have performed, your testing environment,
 and if you have used this in a production setting. Please add
 screenshots if appropriate.
-->

The monsters above now only return current released generations.

Example:
Previously, Teddiursa returned [217, 901] (Ursaring and Ursaking) with a candy cost respectively set to [50, 0].
Now, this mon returns [217] (Ursaring) with a candy cost set to [50].

## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change in doc/*.rst files.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [ ] This change requires an update to the Wiki.
- [x] This change does not require an update to the Wiki.