### PR TITLE
Grunt images are back in alarms

### DIFF
--- a/PokeAlarm/Alarms/Discord/DiscordAlarm.py
+++ b/PokeAlarm/Alarms/Discord/DiscordAlarm.py
@@ -104,9 +104,9 @@ class DiscordAlarm(Alarm):
             'username': "Invasion",
             'content': "",
             'icon_url':
-                get_image_url("regular/invasions/<type_id_3>.png"),
+                get_image_url("regular/invasions/<grunt_id_3>.png"),
             'avatar_url':
-                get_image_url("regular/invasions/<type_id_3>.png"),
+                get_image_url("regular/invasions/<grunt_id_3>.png"),
             'title': "This Pokestop has been invaded by Team Rocket!",
             'url': "<gmaps>",
             'body': "Invasion will expire at <24h_time> (<time_left>).",

--- a/PokeAlarm/Alarms/FacebookPage/FacebookPageAlarm.py
+++ b/PokeAlarm/Alarms/FacebookPage/FacebookPageAlarm.py
@@ -91,7 +91,7 @@ class FacebookPageAlarm(Alarm):
         'invasions': {
             'message': 'This Pokestop has been invaded by Team Rocket!',
             'image':
-                get_image_url("regular/invasions/<type_id_3>.png"),
+                get_image_url("regular/invasions/<grunt_id_3>.png"),
             'link': '<gmaps>',
             'name': 'Invasion',
             'description': 'Invasion will expire at <24h_time> (<time_left>).',

--- a/PokeAlarm/Alarms/Slack/SlackAlarm.py
+++ b/PokeAlarm/Alarms/Slack/SlackAlarm.py
@@ -82,7 +82,7 @@ class SlackAlarm(Alarm):
             'username': "Invasion",
             'content': "",
             'icon_url':
-                get_image_url("regular/invasions/<type_id_3>.png"),
+                get_image_url("regular/invasions/<grunt_id_3>.png"),
             'title': "This Pokestop has been invaded by Team Rocket!",
             'url': "<gmaps>",
             'body': "Invasion will expire at <24h_time> (<time_left>)."

--- a/PokeAlarm/Alarms/Telegram/TelegramAlarm.py
+++ b/PokeAlarm/Alarms/Telegram/TelegramAlarm.py
@@ -76,7 +76,7 @@ class TelegramAlarm(Alarm):
             'message': "A Pokestop has been invaded by Team Rocket!\n"
                        "Invasion will expire at <24h_time> (<time_left>).",
             'sticker_url':
-                get_image_url("telegram/invasions/<type_id_3>.webp")
+                get_image_url("telegram/invasions/<grunt_id_3>.webp")
         }
     }
 

--- a/docs/configuration/alarms/discord.rst
+++ b/docs/configuration/alarms/discord.rst
@@ -190,8 +190,8 @@ Example: Alarm Configuration Using Optional Parameters
       "invasions":{
           "webhook_url":"DISCORD_WEBHOOK_URL_FOR_INVASION_CHANNEL",
           "username":"Invasion",
-          "icon_url*":"YOUR CUSTOM URL HERE/<type_id>_<gender_id>.png",
-          "avatar_url*":"YOUR CUSTOM URL HERE/<type_id>_<gender_id>.png",
+          "icon_url*":"YOUR CUSTOM URL HERE/<grunt_id>_<gender_id>.png",
+          "avatar_url*":"YOUR CUSTOM URL HERE/<grunt_id>_<gender_id>.png",
           "title":"This Pokestop has been invaded by Team Rocket!",
           "url":"<gmaps>",
           "body":"Invasion will expire at <24h_time> (<time_left>)"

--- a/tools/webhook_test.py
+++ b/tools/webhook_test.py
@@ -423,7 +423,11 @@ def get_raw_form_names():
 def get_invasion_list_str():
     invasions_str = ""
     for id_ in invasions_data:
-        invasions_str += f"{id_}: {invasions_data[id_]['type']}\n"
+        grunt_info = invasions_data[id_].get('type')
+        if grunt_info == "":
+            grunt_info = invasions_data[id_].get('grunt')
+        if grunt_info != "":
+            invasions_str += f"{id_}: {grunt_info}\n"
 
     return invasions_str
 


### PR DESCRIPTION
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->


<!--
 Please make all PRs to the dev branch. The dev branch will be
 periodically pulled into the master branch. This allows time for
 the changes and documentation to be tested before being exposed to
 a wider population.
--->

## Description
<!-- In detail, describe what your PR adds to PokeAlarm -->
This PR fixes a bug causing grunt images to not load since the DTS rename of `grunt_id` in a recent PR (https://github.com/pokealarm/pokealarm/pull/823).

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
<!---
 Why is this change required? What problem does it solve?
 If it fixes an open issue, please link to the issue here.
-->
Reported by someone in Discord and in Github
Fixes https://github.com/pokealarm/pokealarm/issues/841

## How Has This Been Tested?
<!---
 Please describe in detail how you tested your changes. Make sure to
 describe what tests you have performed, your testing environment,
 and if you have used this in a production setting. Please add
 screenshots if appropriate.
-->
Webhook tester

## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change in doc/*.rst files.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [ ] This change requires an update to the Wiki.
- [x] This change does not require an update to the Wiki.