### PR TITLE
Add guards DTS to raid and egg events

### DIFF
--- a/PokeAlarm/Cache/Cache.py
+++ b/PokeAlarm/Cache/Cache.py
@@ -26,6 +26,7 @@ class Cache(object):
         self._quest_hist = {}
         self._grunt_hist = {}
         self._gym_team = {}
+        self._gym_slots = {}
         self._gym_name = {}
         self._gym_desc = {}
         self._gym_image = {}
@@ -77,6 +78,12 @@ class Cache(object):
         if Unknown.is_not(team_id):
             self._gym_team[gym_id] = team_id
         return self._gym_team.get(gym_id, Unknown.TINY)
+
+    def gym_slots(self, gym_id, available_slots=Unknown.TINY):
+        """ Update and return the team_id of a gym. """
+        if Unknown.is_not(available_slots):
+            self._gym_slots[gym_id] = available_slots
+        return self._gym_slots.get(gym_id, Unknown.TINY)
 
     def gym_name(self, gym_id, gym_name=Unknown.REGULAR):
         """ Update and return the gym_name for a gym. """

--- a/PokeAlarm/Events/EggEvent.py
+++ b/PokeAlarm/Events/EggEvent.py
@@ -45,6 +45,8 @@ class EggEvent(BaseEvent):
             str, data.get('description'), Unknown.REGULAR).strip()
         self.gym_image = check_for_none(
             str, data.get('url'), Unknown.REGULAR)
+        self.slots_available = Unknown.TINY
+        self.guard_count = Unknown.TINY
 
         self.sponsor_id = check_for_none(
             int, data.get('sponsor'), Unknown.TINY)
@@ -66,8 +68,12 @@ class EggEvent(BaseEvent):
     def update_with_cache(self, cache):
         """ Update event infos using cached data from previous events. """
 
-        # Nothing to update
-        pass
+        # Update available slots
+        self.slots_available = cache.gym_slots(self.gym_id)
+        self.guard_count = (
+            (6 - self.slots_available)
+            if Unknown.is_not(self.slots_available)
+            else Unknown.TINY)
 
     def generate_dts(self, locale, timezone, units):
         """ Return a dict with all the DTS for this event. """
@@ -133,6 +139,8 @@ class EggEvent(BaseEvent):
             'gym_name': self.gym_name,
             'gym_description': self.gym_description,
             'gym_image': self.gym_image,
+            'slots_available': self.slots_available,
+            'guard_count': self.guard_count,
             'sponsor_id': self.sponsor_id,
             'sponsored':
                 self.sponsor_id > 0

--- a/PokeAlarm/Events/RaidEvent.py
+++ b/PokeAlarm/Events/RaidEvent.py
@@ -88,6 +88,8 @@ class RaidEvent(BaseEvent):
             str, data.get('description'), Unknown.REGULAR).strip()
         self.gym_image = check_for_none(
             str, data.get('url'), Unknown.REGULAR)
+        self.slots_available = Unknown.TINY
+        self.guard_count = Unknown.TINY
 
         self.sponsor_id = check_for_none(
             int, data.get('sponsor'), Unknown.TINY)
@@ -118,6 +120,13 @@ class RaidEvent(BaseEvent):
             if is_weather_boosted(self.weather_id, self.mon_id, self.form_id):
                 self.boosted_weather_id = self.weather_id
                 self.boss_level = 25
+
+        # Update available slots
+        self.slots_available = cache.gym_slots(self.gym_id)
+        self.guard_count = (
+            (6 - self.slots_available)
+            if Unknown.is_not(self.slots_available)
+            else Unknown.TINY)
 
     def generate_dts(self, locale, timezone, units):
         """ Return a dict with all the DTS for this event. """
@@ -272,6 +281,8 @@ class RaidEvent(BaseEvent):
             'gym_name': self.gym_name,
             'gym_description': self.gym_description,
             'gym_image': self.gym_image,
+            'slots_available': self.slots_available,
+            'guard_count': self.guard_count,
             'sponsor_id': self.sponsor_id,
             'sponsored':
                 self.sponsor_id > 0 if Unknown.is_not(self.sponsor_id)

--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -850,6 +850,7 @@ class Manager(object):
         # Update Team Information
         gym.old_team_id = self.__cache.gym_team(gym.gym_id)
         self.__cache.gym_team(gym.gym_id, gym.new_team_id)
+        self.__cache.gym_slots(gym.gym_id, gym.slots_available)
 
         # Check if notifications are on
         if self._gyms_enabled is False:

--- a/docs/configuration/events/egg-events.rst
+++ b/docs/configuration/events/egg-events.rst
@@ -35,6 +35,8 @@ egg_lvl           The tier level of the egg.
 gym_name          The name of the gym. *
 gym_description   The description of the gym. *
 gym_image         The url to the image of the gym. *
+slots_available   Number of open guard slots available in a gym.
+guard_count       Number of guards assigned to a gym.
 ex_eligible       True if the gym currently has an ex tag, False if not.
 is_exclusive      True if the egg is for an ex raid, False if not.
 park              The name of the park the gym is located in.

--- a/docs/configuration/events/raid-events.rst
+++ b/docs/configuration/events/raid-events.rst
@@ -67,6 +67,8 @@ shiny_emoji                Return shiny emoji if monster can be shiny, or
 gym_name                   The name of the gym. *
 gym_description            The description of the gym. *
 gym_image                  The url to the image of the gym. *
+slots_available            Number of open guard slots available in a gym.
+guard_count                Number of guards assigned to a gym.
 team_id                    The id of the team currently in control of the gym.
 team_emoji                 The team color currently in control of the gym.
 team_name                  The team currently in control of the gym.


### PR DESCRIPTION
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->


<!--
 Please make all PRs to the dev branch. The dev branch will be
 periodically pulled into the master branch. This allows time for
 the changes and documentation to be tested before being exposed to
 a wider population.
--->

## Description
<!-- In detail, describe what your PR adds to PokeAlarm -->
Add `slots_available` and `guard_count` DTS for raid and egg events (still available in gym event).

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
<!---
 Why is this change required? What problem does it solve?
 If it fixes an open issue, please link to the issue here.
-->
With the new cache system use introduced in #836, it is now possible to dynamically update an event using the cached informations of other event types.
Will close #755

## How Has This Been Tested?
<!---
 Please describe in detail how you tested your changes. Make sure to
 describe what tests you have performed, your testing environment,
 and if you have used this in a production setting. Please add
 screenshots if appropriate.
-->
On a live configuration
When all gyms are cached, the new DTS work as expected.

## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change in doc/*.rst files.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [x] This change includes an update to the Wiki.
- [ ] This change requires an update to the Wiki.
- [ ] This change does not require an update to the Wiki.