### PR TITLE
Normal monster forms are now retrieved to calculate their PvP rank

### DIFF
--- a/PokeAlarm/Utils.py
+++ b/PokeAlarm/Utils.py
@@ -474,6 +474,9 @@ def get_proto_name(pokemon_id, form_id=0):
                     proto_name = proto_name.replace(
                         '_ALOLA', '_ALOLAN').lower()
                     get_proto_name.info[f'{id_}_{form_id_}'] = proto_name
+                else:
+                    get_proto_name.info[
+                        f'{id_}_0'] = f'{j[id_]["name"]}_normal'.lower()
 
     return get_proto_name.info.get(f'{pokemon_id}_{form_id}', Unknown.REGULAR)
 


### PR DESCRIPTION
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->


<!--
 Please make all PRs to the dev branch. The dev branch will be
 periodically pulled into the master branch. This allows time for
 the changes and documentation to be tested before being exposed to
 a wider population.
--->

## Description
<!-- In detail, describe what your PR adds to PokeAlarm -->
This PR fixes a bug where normal form of monsters were not retrieved correctly to calculate its PvP rank and so #∞ was displayed instead of the real rank.
The least good monsters (> 500th) rank is still displayed as #∞.

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
<!---
 Why is this change required? What problem does it solve?
 If it fixes an open issue, please link to the issue here.
-->
Minor bug introduced in #837 
Fixes #846, thanks for reporting this!

## How Has This Been Tested?
<!---
 Please describe in detail how you tested your changes. Make sure to
 describe what tests you have performed, your testing environment,
 and if you have used this in a production setting. Please add
 screenshots if appropriate.
-->
New test cases with the webhook worker.
Ex: Greninja which have any form set displayed rank ∞ instead of ~ 300

## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change in doc/*.rst files.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [ ] This change requires an update to the Wiki.
- [x] This change does not require an update to the Wiki.