### PR TITLE
New max CP and costs DTS for monster evolutions

### DIFF
--- a/PokeAlarm/Events/MonEvent.py
+++ b/PokeAlarm/Events/MonEvent.py
@@ -279,7 +279,7 @@ class MonEvent(BaseEvent):
             # Max out
             'max_cp': calculate_cp(self.monster_id, self.form_id,
                                    self.atk_iv, self.def_iv, self.sta_iv,
-                                   self.mon_lvl),
+                                   50),
             'max_perfect_cp': max_cp(self.monster_id, self.form_id),
             'stardust_cost': calculate_stardust_cost(self.mon_lvl, 50),
             'candy_cost': calculate_candy_cost(self.mon_lvl, 50),

--- a/PokeAlarm/Events/MonEvent.py
+++ b/PokeAlarm/Events/MonEvent.py
@@ -294,14 +294,14 @@ class MonEvent(BaseEvent):
             'max_cp': calculate_cp(self.monster_id, self.form_id,
                                    self.atk_iv, self.def_iv, self.sta_iv, 50),
             'max_perfect_cp': max_cp(self.monster_id, self.form_id),
-
+            'stardust_cost': calculate_stardust_cost(self.mon_lvl, 50),
+            'candy_cost': calculate_candy_cost(self.mon_lvl, 50),
             'max_evo_cp': calculate_cp(last_evo_id, last_evo_form_id,
                                        self.atk_iv, self.def_iv, self.sta_iv,
                                        50),
             'max_perfect_evo_cp': max_cp(last_evo_id, last_evo_form_id),
-            'stardust_cost': calculate_stardust_cost(self.mon_lvl, 50),
-            'candy_cost': calculate_candy_cost(self.mon_lvl, 50,
-                                               evo_candy_cost),
+            'candy_cost_with_evo': calculate_candy_cost(self.mon_lvl, 50,
+                                                        evo_candy_cost),
 
             # IVs
             'iv_0': (

--- a/PokeAlarm/Events/MonEvent.py
+++ b/PokeAlarm/Events/MonEvent.py
@@ -210,8 +210,9 @@ class MonEvent(BaseEvent):
         last_evo_id = self.monster_id
         last_evo_form_id = self.form_id
         if len(evo_details) > 0:
-            last_evo_id = evo_details[-1][:evo_details[-1].find('_')]
-            last_evo_form_id = evo_details[-1][evo_details[-1].find('_') + 1:]
+            last_evo_id = int(evo_details[-1][:evo_details[-1].find('_')])
+            last_evo_form_id = int(
+                evo_details[-1][evo_details[-1].find('_') + 1:])
 
         evo_candy_cost = calculate_evolution_cost(
             self.monster_id, last_evo_id, evo_details, evolution_costs)

--- a/PokeAlarm/Events/RaidEvent.py
+++ b/PokeAlarm/Events/RaidEvent.py
@@ -11,7 +11,7 @@ from PokeAlarm.Utils import get_gmaps_link, get_applemaps_link, \
     get_base_types, get_weather_emoji, get_type_emoji, get_waze_link, \
     get_team_emoji, get_ex_eligible_emoji, get_shiny_emoji, \
     get_gender_sym, get_cached_weather_id_from_coord, max_cp, \
-    calculate_candy_cost, calculate_stardust_cost
+    calculate_candy_cost, calculate_stardust_cost, get_evolutions
 from PokeAlarm.Utilities import MonUtils
 
 
@@ -148,6 +148,15 @@ class RaidEvent(BaseEvent):
 
         cp_range = get_pokemon_cp_range(
             self.boss_level, self.mon_id, self.form_id)
+
+        evo_details = get_evolutions(
+            self.mon_id, self.form_id, True)
+        last_evo_id = self.mon_id
+        last_evo_form_id = self.form_id
+        if len(evo_details) > 0:
+            last_evo_id = evo_details[-1][:evo_details[-1].find('_')]
+            last_evo_form_id = evo_details[-1][evo_details[-1].find('_') + 1:]
+
         dts.update({
             # Identification
             'gym_id': self.gym_id,
@@ -280,6 +289,7 @@ class RaidEvent(BaseEvent):
 
             # Max out
             'max_perfect_cp': max_cp(self.mon_id, self.form_id),
+            'max_perfect_evo_cp': max_cp(last_evo_id, last_evo_form_id),
             'stardust_cost': calculate_stardust_cost(self.raid_lvl, 50),
             'candy_cost': calculate_candy_cost(self.raid_lvl, 50),
 

--- a/PokeAlarm/Utilities/PvpUtils.py
+++ b/PokeAlarm/Utilities/PvpUtils.py
@@ -28,25 +28,6 @@ def pokemon_rating(limit, monster_id, form_id, atk, de, sta,
     return highest_rating, highest_cp, highest_level
 
 
-def calculate_evolution_cost(monster_id, target_id, evolutions,
-                             evolution_costs):
-    if monster_id == target_id or not ([True for s in evolutions
-                                        if f"{target_id}_" in s]):
-        return 0
-    evo_candy_cost = evolution_costs[0]
-
-    for evolution in evolutions:
-        evo_id, evo_form_id = re.findall(r"[\.\d]+", evolution)
-        evo_id = int(evo_id)
-        evo_form_id = int(evo_form_id)
-
-        if evo_id == target_id:
-            return evo_candy_cost
-        evo_candy_cost += evolution_costs[1]
-
-    return evo_candy_cost
-
-
 def get_pvp_info(monster_id, form_id, atk, de, sta, lvl):
     lvl = float(lvl)
 
@@ -118,7 +99,7 @@ def get_pvp_info(monster_id, form_id, atk, de, sta, lvl):
             great_cp = evo_great_cp
             great_level = evo_great_level
             great_id = evo_id
-            evo_candy_cost = calculate_evolution_cost(
+            evo_candy_cost = utils.calculate_evolution_cost(
                 monster_id, evo_id, evolutions, evolution_costs)
             great_candy = utils.calculate_candy_cost(
                 lvl, great_level, evo_candy_cost)
@@ -130,7 +111,7 @@ def get_pvp_info(monster_id, form_id, atk, de, sta, lvl):
             ultra_cp = evo_ultra_cp
             ultra_level = evo_ultra_level
             ultra_id = evo_id
-            evo_candy_cost = calculate_evolution_cost(
+            evo_candy_cost = utils.calculate_evolution_cost(
                 monster_id, evo_id, evolutions, evolution_costs)
             ultra_candy = utils.calculate_candy_cost(
                 lvl, ultra_level, evo_candy_cost)

--- a/PokeAlarm/Utils.py
+++ b/PokeAlarm/Utils.py
@@ -702,6 +702,25 @@ def calculate_stardust_cost(start_level, target_level):
     return f'{stardust_cost:,}'.replace(',', ' ')
 
 
+def calculate_evolution_cost(monster_id, target_id, evolutions,
+                             evolution_costs):
+    if monster_id == target_id or not ([True for s in evolutions
+                                        if f"{target_id}_" in s]):
+        return 0
+    evo_candy_cost = evolution_costs[0]
+
+    for evolution in evolutions:
+        evo_id, evo_form_id = re.findall(r"[\.\d]+", evolution)
+        evo_id = int(evo_id)
+        evo_form_id = int(evo_form_id)
+
+        if evo_id == target_id:
+            return evo_candy_cost
+        evo_candy_cost += evolution_costs[1]
+
+    return evo_candy_cost
+
+
 # Return the list of candy costs for powering up a pokemon
 def get_candy_costs():
     if not hasattr(get_candy_costs, 'info'):

--- a/docs/configuration/events/monster-events.rst
+++ b/docs/configuration/events/monster-events.rst
@@ -80,6 +80,8 @@ def                 Defense IV of the monster.
 sta                 Stamina IV of the monster.
 max_cp              Final CP after maxed out the monster.
 max_perfect_cp      Final CP after maxed out a perfect IV monster.
+max_evo_cp          Final CP after evolved and maxed out the monster.
+max_perfect_evo_cp  Final CP after evolved and maxed out a perfect IV monster.
 stardust_cost       Stardust cost to power up the monster to its max level.
 candy_cost          Candy cost to power up the monster to its max level.
 base_catch          Catch rate of the monster when using a poke ball.

--- a/docs/configuration/events/monster-events.rst
+++ b/docs/configuration/events/monster-events.rst
@@ -67,34 +67,35 @@ Stats
     settings and accounts - see the documentation for your scanner for
     specifics.
 
-=================== =========================================================
-DTS                 Description
-=================== =========================================================
-mon_lvl             Level of the monster.
-cp                  Combat Points of the monster.
-iv                  Individual Values percentage of the monster.
-iv_0                IVs, rounded to the nearest integer.
-iv_2                IVs, rounded to 2 decimal places.
-atk                 Attack IV of the monster.
-def                 Defense IV of the monster.
-sta                 Stamina IV of the monster.
-max_cp              Final CP after maxed out the monster.
-max_perfect_cp      Final CP after maxed out a perfect IV monster.
-max_evo_cp          Final CP after evolved and maxed out the monster.
-max_perfect_evo_cp  Final CP after evolved and maxed out a perfect IV monster.
-stardust_cost       Stardust cost to power up the monster to its max level.
-candy_cost          Candy cost to power up the monster to its max level.
-base_catch          Catch rate of the monster when using a poke ball.
-base_catch_0        Catch rate of the monster when using a poke ball, rounded to the nearest integer.
-base_catch_2        Catch rate of the monster when using a poke ball, rounded to 2 decimal places.
-great_catch         Catch rate of the monster when using a great ball.
-great_catch_0       Catch rate of the monster when using a great ball, rounded to the nearest integer.
-great_catch_2       Catch rate of the monster when using a great ball, rounded to 2 decimal places.
-ultra_catch         Catch rate of the monster when using an ultra ball.
-ultra_catch_0       Catch rate of the monster when using an ultra ball, rounded to the nearest integer.
-ultra_catch_2       Catch rate of the monster when using an ultra ball, rounded to 2 decimal places.
-rarity              Rarity of the monster, as supplied by the scanner.
-=================== =========================================================
+===================== =========================================================
+DTS                   Description
+===================== =========================================================
+mon_lvl               Level of the monster.
+cp                    Combat Points of the monster.
+iv                    Individual Values percentage of the monster.
+iv_0                  IVs, rounded to the nearest integer.
+iv_2                  IVs, rounded to 2 decimal places.
+atk                   Attack IV of the monster.
+def                   Defense IV of the monster.
+sta                   Stamina IV of the monster.
+max_cp                Final CP after maxed out the monster.
+max_perfect_cp        Final CP after maxed out a perfect IV monster.
+max_evo_cp            Final CP after evolved and maxed out the monster.
+max_perfect_evo_cp    Final CP after evolved and maxed out a perfect IV monster.
+stardust_cost         Stardust cost to power up the monster to its max level.
+candy_cost            Candy cost to power up the monster to its max level.
+candy_cost_with_evo   Candy cost to evolve and power up the monster to its max level.
+base_catch            Catch rate of the monster when using a poke ball.
+base_catch_0          Catch rate of the monster when using a poke ball, rounded to the nearest integer.
+base_catch_2          Catch rate of the monster when using a poke ball, rounded to 2 decimal places.
+great_catch           Catch rate of the monster when using a great ball.
+great_catch_0         Catch rate of the monster when using a great ball, rounded to the nearest integer.
+great_catch_2         Catch rate of the monster when using a great ball, rounded to 2 decimal places.
+ultra_catch           Catch rate of the monster when using an ultra ball.
+ultra_catch_0         Catch rate of the monster when using an ultra ball, rounded to the nearest integer.
+ultra_catch_2         Catch rate of the monster when using an ultra ball, rounded to 2 decimal places.
+rarity                Rarity of the monster, as supplied by the scanner.
+===================== =========================================================
 
 Moves
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/configuration/events/raid-events.rst
+++ b/docs/configuration/events/raid-events.rst
@@ -76,6 +76,7 @@ team_leader                The leader of the team currently in control of the gy
 sponsor_id                 The sponsor if of the gym. 0 if not sponsored.
 sponsored                  True if sponsored, False if not.
 max_perfect_cp             Final CP after maxed out a perfect IV monster.
+max_perfect_evo_cp         Final CP after evolved and maxed out a perfect IV monster.
 stardust_cost              Stardust cost to power up the monster to its max level.
 candy_cost                 Candy cost to power up the monster to its max level.
 ========================== ============================================================


### PR DESCRIPTION
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->


<!--
 Please make all PRs to the dev branch. The dev branch will be
 periodically pulled into the master branch. This allows time for
 the changes and documentation to be tested before being exposed to
 a wider population.
--->

## Description
<!-- In detail, describe what your PR adds to PokeAlarm -->

1. New DTS:
- `max_perfect_evo_cp` : Final CP after evolved and maxed out a perfect IV monster (monster and raid events)
- `max_evo_cp` : Final CP after evolved and maxed out the monster (monster event)
- `candy_cost_with_evo` : Candy cost to evolve and power up the monster to its max level (monster event)

3. Fixed a bug where current monster level were used to calculate max CP instead of max level


## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
<!---
 Why is this change required? What problem does it solve?
 If it fixes an open issue, please link to the issue here.
-->

The current DTS without evolution gave the max CP and cost for the current monster id.
I think it's even better if you know what CP can a monster reach after being fully evolved. When you catch a Slakoth, you prefer to know that once evolved, he reaches 5010 CP rather than know Slakoth's max CP is 1133.

## How Has This Been Tested?
<!---
 Please describe in detail how you tested your changes. Make sure to
 describe what tests you have performed, your testing environment,
 and if you have used this in a production setting. Please add
 screenshots if appropriate.
-->
With my live config. The CP and candy/stardust costs calculation functions are still used in PvP.

## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change in doc/*.rst files.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [x] This change includes an update to the Wiki.
- [ ] This change requires an update to the Wiki.
- [ ] This change does not require an update to the Wiki.