### PR TITLE
Use weather boosted status (true or false) instead of weather id to cache a monster

### DIFF
--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -23,7 +23,8 @@ from .LocationServices import GMaps
 from PokeAlarm import Unknown
 from PokeAlarm.Utilities.Logging import ContextFilter, setup_file_handler
 from PokeAlarm.Utilities.GenUtils import parse_bool
-from .Utils import (get_earth_dist, get_path, get_cardinal_dir)
+from .Utils import (get_earth_dist, get_path,
+                    get_cardinal_dir, is_weather_boosted)
 from . import config
 Rule = namedtuple('Rule', ['filter_names', 'alarm_names'])
 
@@ -665,15 +666,17 @@ class Manager(object):
 
         # Set the name for this event so we can log rejects better
         mon.name = self.__locale.get_pokemon_name(mon.monster_id)
+        boosted_status = int(is_weather_boosted(
+            mon.weather_id, mon.monster_id, mon.form_id))
 
         # Check if previously processed and update expiration
         if self.__cache.monster_expiration(
-                f'{mon.enc_id}{mon.weight}_{mon.weather_id}') is not None:
+                f'{mon.enc_id}{mon.weight}{boosted_status}') is not None:
             self._log.debug("{} monster was skipped because it was "
                             "previously processed.".format(mon.name))
             return
         self.__cache.monster_expiration(
-            f'{mon.enc_id}{mon.weight}_{mon.weather_id}',
+            f'{mon.enc_id}{mon.weight}{boosted_status}',
             mon.disappear_time)
 
         # Check the time remaining


### PR DESCRIPTION
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->


<!--
 Please make all PRs to the dev branch. The dev branch will be
 periodically pulled into the master branch. This allows time for
 the changes and documentation to be tested before being exposed to
 a wider population.
--->

## Description
<!-- In detail, describe what your PR adds to PokeAlarm -->

Informations used to cache a monster are now:
- its encounter id
- its pokedex id (before: its weight)
- its weather boosted status (before: current weather id)

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
<!---
 Why is this change required? What problem does it solve?
 If it fixes an open issue, please link to the issue here.
-->
Reminders:
- PokeAlarm uses a cache system to not ping 10 times the same monster.
- When the weather changes, the IV changes for the monsters which go from weather boosted to unboosted (or the opposite)

Before Weather update #836:
- the weather information was not used to cache a monster
- That means if a newly boosted monster would pass new filters due to IV changes, it would not trigger any alarm because it's considered as the same monster from the cache system.

Before this PR:
- the current weather id was used to cache a monster
- That means the above problem was fixed
- But for monsters with 2 types, they can be boosted by 2 different weathers (= 2 differents weather id). That means if the IV of a monster which triggers an alarm doesn't change when the weather changes (from unboosted to unboosted or from boosted to boosted), it will trigger the same alarm whereas it's the same monster.

Now with this PR:
- The boosted status is used to know if the monster is boosted or not
- That means the above problems are fixed

## How Has This Been Tested?
<!---
 Please describe in detail how you tested your changes. Make sure to
 describe what tests you have performed, your testing environment,
 and if you have used this in a production setting. Please add
 screenshots if appropriate.
-->

With `webhook_tester.py` (modified to always use the same encounter id), I generated a Bulbizarre alarm (grass/poison monster boosted by Clear and Cloody weather). I printed the informations used by the cache system to determine if the monster is still know or not (`{mon.enc_id}{mon.weight}{boosted_status}`

```
78785145???1 (Clear weather)
2022-10-31 11:25:50,981 [ INFO][ manager_0][     rules] Monster Bulbizarre passed 1 rule(s) and triggered 1 alarm(s).
78785145???1 (Clear weather)
78785145???1 (Clear weather)
78785145???1 (Cloudy weather)
78785145???1 (Cloudy weather)
78785145???0 (Fog weather)
2022-10-31 11:30:31,215 [ INFO][ manager_0][     rules] Monster Bulbizarre passed 1 rule(s) and triggered 1 alarm(s).
78785145???0 (Fog weather)
78785145???0 (Snow weather)
```

The same weather state only triggers 1 alarm.

## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change in doc/*.rst files.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [ ] This change requires an update to the Wiki.
- [x] This change does not require an update to the Wiki.