### PR TITLE
RDM and MAD dts full support

### DIFF
--- a/PokeAlarm/Events/EggEvent.py
+++ b/PokeAlarm/Events/EggEvent.py
@@ -30,13 +30,10 @@ class EggEvent(BaseEvent):
         self.gym_id = data.get("gym_id")
 
         # Time Remaining
-        self.hatch_time = datetime.utcfromtimestamp(
-            data.get("start") or data.get("raid_begin")
-        )  # RM or Monocle
-        self.time_left = get_seconds_remaining(self.hatch_time)
-        self.raid_end = datetime.utcfromtimestamp(
-            data.get("end") or data.get("raid_end")
-        )  # RM or Monocle
+        self.egg_spawn_utc = datetime.utcfromtimestamp(data.get("spawn", 0))
+        self.raid_start_utc = datetime.utcfromtimestamp(data.get("start", 0))
+        self.raid_end_utc = datetime.utcfromtimestamp(data.get("end", 0))
+        self.time_left = get_seconds_remaining(self.raid_start_utc)
 
         # Location
         self.lat = float(data["latitude"])
@@ -48,19 +45,28 @@ class EggEvent(BaseEvent):
         # Egg Info
         self.egg_lvl = check_for_none(int, data.get("level"), 0)
 
-        # Gym Details (currently only sent from Monocle)
-        self.gym_name = check_for_none(str, data.get("name"), Unknown.REGULAR).strip()
+        # Gym Details
+        self.gym_name = check_for_none(
+            str, data.get("name", data.get("gym_name")), Unknown.REGULAR
+        ).strip()
         self.gym_description = check_for_none(
             str, data.get("description"), Unknown.REGULAR
         ).strip()
-        self.gym_image = check_for_none(str, data.get("url"), Unknown.REGULAR)
+        self.gym_image = check_for_none(
+            str, data.get("url", data.get("gym_url")), Unknown.REGULAR
+        )
         self.slots_available = Unknown.TINY
         self.guard_count = Unknown.TINY
 
         self.sponsor_id = check_for_none(int, data.get("sponsor"), Unknown.TINY)
+        self.partner_id = check_for_none(
+            int, data.get("partner_id"), Unknown.TINY
+        )  # RDM only
         self.park = check_for_none(str, data.get("park"), Unknown.REGULAR)
         self.ex_eligible = check_for_none(
-            int, data.get("is_ex_raid_eligible"), Unknown.REGULAR
+            int,
+            data.get("is_ex_raid_eligible", data.get("ex_raid_eligible")),
+            Unknown.REGULAR,
         )
         self.is_exclusive = check_for_none(
             int, data.get("is_exclusive"), Unknown.REGULAR
@@ -88,36 +94,48 @@ class EggEvent(BaseEvent):
 
     def generate_dts(self, locale, timezone, units):
         """Return a dict with all the DTS for this event."""
-        hatch_time = get_time_as_str(self.hatch_time, timezone)
-        raid_end_time = get_time_as_str(self.raid_end, timezone)
+        egg_spawn = get_time_as_str(self.egg_spawn_utc, timezone)
+        raid_start = get_time_as_str(self.raid_start_utc, timezone)
+        raid_end = get_time_as_str(self.raid_end_utc, timezone)
         weather_name = locale.get_weather_name(self.weather_id)
         dts = self.custom_dts.copy()
         dts.update(
             {
                 # Identification
                 "gym_id": self.gym_id,
+                # Spawn Time
+                "spawn_time": egg_spawn[0],
+                "12h_spawn_time": egg_spawn[1],
+                "24h_spawn_time": egg_spawn[2],
+                "spawn_time_no_secs": egg_spawn[3],
+                "12h_spawn_time_no_secs": egg_spawn[4],
+                "24h_spawn_time_no_secs": egg_spawn[5],
+                "spawn_time_raw_hours": egg_spawn[6],
+                "spawn_time_raw_minutes": egg_spawn[7],
+                "spawn_time_raw_seconds": egg_spawn[8],
+                "spawn_time_utc": self.egg_spawn_utc.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                 # Hatch Time Remaining
-                "hatch_time_left": hatch_time[0],
-                "12h_hatch_time": hatch_time[1],
-                "24h_hatch_time": hatch_time[2],
-                "hatch_time_no_secs": hatch_time[3],
-                "12h_hatch_time_no_secs": hatch_time[4],
-                "24h_hatch_time_no_secs": hatch_time[5],
-                "hatch_time_raw_hours": hatch_time[6],
-                "hatch_time_raw_minutes": hatch_time[7],
-                "hatch_time_raw_seconds": hatch_time[8],
-                "hatch_time_utc": self.hatch_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "hatch_time_left": raid_start[0],
+                "12h_hatch_time": raid_start[1],
+                "24h_hatch_time": raid_start[2],
+                "hatch_time_no_secs": raid_start[3],
+                "12h_hatch_time_no_secs": raid_start[4],
+                "24h_hatch_time_no_secs": raid_start[5],
+                "hatch_time_raw_hours": raid_start[6],
+                "hatch_time_raw_minutes": raid_start[7],
+                "hatch_time_raw_seconds": raid_start[8],
+                "hatch_time_utc": self.raid_start_utc.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                 # Raid Time Remaining
-                "raid_time_left": raid_end_time[0],
-                "12h_raid_end": raid_end_time[1],
-                "24h_raid_end": raid_end_time[2],
-                "raid_time_no_secs": raid_end_time[3],
-                "12h_raid_end_no_secs": raid_end_time[4],
-                "24h_raid_end_no_secs": raid_end_time[5],
-                "raid_time_raw_hours": raid_end_time[6],
-                "raid_time_raw_minutes": raid_end_time[7],
-                "raid_time_raw_seconds": raid_end_time[8],
-                "raid_end_utc": self.raid_end,
+                "raid_time_left": raid_end[0],
+                "12h_raid_end": raid_end[1],
+                "24h_raid_end": raid_end[2],
+                "raid_time_no_secs": raid_end[3],
+                "12h_raid_end_no_secs": raid_end[4],
+                "24h_raid_end_no_secs": raid_end[5],
+                "raid_time_raw_hours": raid_end[6],
+                "raid_time_raw_minutes": raid_end[7],
+                "raid_time_raw_seconds": raid_end[8],
+                "raid_end_utc": self.raid_end_utc.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                 "current_timestamp_utc": datetime.utcnow(),
                 # Location
                 "lat": self.lat,
@@ -153,6 +171,7 @@ class EggEvent(BaseEvent):
                 "sponsored": self.sponsor_id > 0
                 if Unknown.is_not(self.sponsor_id)
                 else Unknown.REGULAR,
+                "partner_id": self.partner_id,
                 "ex_eligible": self.ex_eligible > 0
                 if Unknown.is_not(self.ex_eligible)
                 else Unknown.REGULAR,

--- a/PokeAlarm/Events/GruntEvent.py
+++ b/PokeAlarm/Events/GruntEvent.py
@@ -46,20 +46,26 @@ class GruntEvent(BaseEvent):
             str, data.get("pokestop_url") or data.get("url"), Unknown.REGULAR
         )
 
-        # Time left
-        self.expiration = datetime.utcfromtimestamp(
-            data.get("incident_expiration", data.get("incident_expire_timestamp"))
+        # Time
+        self.start = datetime.utcfromtimestamp(
+            data.get("incident_start", data.get("start", 0))
         )
-
+        self.expiration = datetime.utcfromtimestamp(
+            data.get("incident_expiration", data.get("expiration", 0))
+        )
         self.time_left = None
         if self.expiration is not None:
             self.time_left = get_seconds_remaining(self.expiration)
 
         # Grunt type ID
         self.grunt_type_id = check_for_none(
-            int, data.get("incident_grunt_type", data.get("grunt_type")), 0
+            int, data.get("incident_grunt_type", data.get("character")), 0
         )
         self.grunt_name = get_grunt_name(self.grunt_type_id)
+
+        # Cosmetic
+        self.display_type = check_for_none(str, data.get("display_type"), 0)
+        self.style = check_for_none(str, data.get("style"), 0)
 
         # Grunt gender
         self.gender_id = get_grunt_gender_id(self.grunt_type_id)
@@ -110,7 +116,8 @@ class GruntEvent(BaseEvent):
 
     def generate_dts(self, locale, timezone, units):
         """Return a dict with all the DTS for this event."""
-        time = get_time_as_str(self.expiration, timezone)
+        start_time = get_time_as_str(self.start, timezone)
+        expiration_time = get_time_as_str(self.expiration, timezone)
         dts = self.custom_dts.copy()
         weather_name = locale.get_weather_name(self.weather_id)
         boosted_weather_name = locale.get_weather_name(self.boosted_weather_id)
@@ -128,6 +135,8 @@ class GruntEvent(BaseEvent):
                 "type_emoji": get_type_emoji(self.mon_type_id),
                 "gender_id": self.gender_id,
                 "gender": self.gender,
+                "display_type": self.display_type,
+                "style": self.style,
                 # Rewards
                 "reward_ids": ", ".join(map(str, self.reward_mon_ids)),
                 "reward_names": ", ".join(
@@ -146,16 +155,27 @@ class GruntEvent(BaseEvent):
                 "battle3_names": ", ".join(
                     map(str, [locale.get_pokemon_name(x) for x in self.mon_battle3_ids])
                 ),
+                # Start Time
+                "start_time": start_time[0],
+                "12h_start_time": start_time[1],
+                "24h_start_time": start_time[2],
+                "start_time_no_secs": start_time[3],
+                "12h_start_time_no_secs": start_time[4],
+                "24h_start_time_no_secs": start_time[5],
+                "start_time_raw_hours": start_time[6],
+                "start_time_raw_minutes": start_time[7],
+                "start_time_raw_seconds": start_time[8],
+                "start_utc": self.start,
                 # Time left
-                "time_left": time[0],
-                "12h_time": time[1],
-                "24h_time": time[2],
-                "time_left_no_secs": time[3],
-                "12h_time_no_secs": time[4],
-                "24h_time_no_secs": time[5],
-                "time_left_raw_hours": time[6],
-                "time_left_raw_minutes": time[7],
-                "time_left_raw_seconds": time[8],
+                "time_left": expiration_time[0],
+                "12h_time": expiration_time[1],
+                "24h_time": expiration_time[2],
+                "time_left_no_secs": expiration_time[3],
+                "12h_time_no_secs": expiration_time[4],
+                "24h_time_no_secs": expiration_time[5],
+                "time_left_raw_hours": expiration_time[6],
+                "time_left_raw_minutes": expiration_time[7],
+                "time_left_raw_seconds": expiration_time[8],
                 "expiration_utc": self.expiration,
                 "current_timestamp_utc": datetime.utcnow(),
                 # Location

--- a/PokeAlarm/Events/GymEvent.py
+++ b/PokeAlarm/Events/GymEvent.py
@@ -43,7 +43,9 @@ class GymEvent(BaseEvent):
         ).strip()
         self.gym_image = check_for_none(str, data.get("url"), Unknown.REGULAR)
         self.ex_eligible = check_for_none(
-            int, data.get("is_ex_raid_eligible"), Unknown.REGULAR
+            int,
+            data.get("is_ex_raid_eligible", data.get("ex_raid_eligible")),
+            Unknown.REGULAR,
         )
 
         # Gym Guards
@@ -55,8 +57,45 @@ class GymEvent(BaseEvent):
             if Unknown.is_not(self.slots_available)
             else Unknown.TINY
         )
+        self.guard_pokemon_id = check_for_none(
+            int, data.get("guard_pokemon_id"), Unknown.TINY
+        )  # RDM only
+        self.total_cp = check_for_none(
+            int, data.get("total_cp"), Unknown.TINY
+        )  # RDM only
+        self.in_battle = check_for_none(
+            int, data.get("is_in_battle", data.get("in_battle")), Unknown.TINY
+        )
+        self.power_up_points = check_for_none(
+            int, data.get("power_up_points"), Unknown.TINY
+        )  # RDM only
+        self.power_up_level = check_for_none(
+            int, data.get("power_up_level"), Unknown.TINY
+        )  # RDM only
+        self.power_up_end_timestamp = datetime.utcfromtimestamp(
+            data.get("power_up_end_timestamp", 0)
+        )  # RDM only
 
-        self.sponsor_id = check_for_none(int, data.get("sponsor"), Unknown.TINY)
+        # Sponsor
+        self.sponsor_id = check_for_none(
+            int, data.get("sponsor", data.get("sponsor_id")), Unknown.TINY
+        )
+        self.partner_id = check_for_none(
+            int, data.get("partner_id"), Unknown.TINY
+        )  # RDM only
+        self.ar_scan_eligible = check_for_none(
+            int,
+            data.get("is_ar_scan_eligible", data.get("ar_scan_eligible")),
+            Unknown.TINY,
+        )
+
+        # Misc
+        self.enabled = check_for_none(
+            int, data.get("enabled"), Unknown.TINY
+        )  # RDM only
+        self.last_modified = datetime.utcfromtimestamp(
+            data.get("last_modified", 0)
+        )  # RDM only
 
         self.name = self.gym_id
         self.geofence = Unknown.REGULAR
@@ -115,11 +154,21 @@ class GymEvent(BaseEvent):
                 # Guards
                 "slots_available": self.slots_available,
                 "guard_count": self.guard_count,
+                "guard_pokemon_id": self.guard_pokemon_id,
+                "total_cp": self.total_cp,
+                "in_battle": self.in_battle,
+                "power_up_points": self.power_up_points,
+                "power_up_level": self.power_up_level,
+                "power_up_end_timestamp": self.power_up_end_timestamp,
                 # Sponsor
                 "sponsor_id": self.sponsor_id,
                 "sponsored": self.sponsor_id > 0
                 if Unknown.is_not(self.sponsor_id)
                 else Unknown.REGULAR,
+                "partner_id": self.partner_id,
+                "ar_scan_eligible": self.ar_scan_eligible,
+                "enabled": self.enabled,
+                "last_modified": self.last_modified,
                 "current_timestamp_utc": datetime.utcnow(),
             }
         )

--- a/PokeAlarm/Events/QuestEvent.py
+++ b/PokeAlarm/Events/QuestEvent.py
@@ -49,17 +49,20 @@ class QuestEvent(BaseEvent):
         self.custom_dts = {}
 
         # Quest Details
-        self.quest_type_raw = data["quest_type"]
+        self.quest_type_raw = data.get("quest_type", data.get("type"))
         self.quest_type_id = data.get("quest_type_raw")
-        self.quest_target = data.get("quest_target")
+        self.quest_target = data.get("quest_target", data.get("target"))
         self.quest_task_raw = data.get("quest_task")
-        self.quest_condition_raw = data.get("quest_condition")
-        self.quest_template = data.get("quest_template")
-        self.last_modified = datetime.utcfromtimestamp(data["timestamp"])
+        self.quest_condition_raw = data.get("quest_condition", data.get("conditions"))
+        self.quest_template = data.get("quest_template", data.get("template"))
+        self.last_modified = datetime.utcfromtimestamp(
+            data.get("timestamp", data.get("updated"))
+        )
 
         # Reward Details
         self.reward_type_id = data["quest_reward_type_raw"]
         self.reward_type_raw = data.get("quest_reward_type")
+        self.reward_raw = data.get("quest_reward_raw", data.get("questRewards"))
         self.reward_amount = data.get("item_amount", 1)
 
         # Monster Reward Details
@@ -81,6 +84,15 @@ class QuestEvent(BaseEvent):
         self.item_amount = self.reward_amount
         self.item_type = data.get("item_type")
         self.item_id = data.get("item_id", 0)
+
+        self.ar_scan_eligible = check_for_none(
+            int,
+            data.get("is_ar_scan_eligible", data.get("ar_scan_eligible")),
+            Unknown.TINY,
+        )
+        self.with_ar = check_for_none(
+            bool, data.get("with_ar"), Unknown.TINY
+        )  # RDM only
 
     def update_with_cache(self, cache):
         """Update event infos using cached data from previous events."""
@@ -119,6 +131,9 @@ class QuestEvent(BaseEvent):
                 "waze": get_waze_link(self.lat, self.lng, False),
                 "wazenav": get_waze_link(self.lat, self.lng, True),
                 "geofence": self.geofence,
+                # AR details
+                "ar_scan_eligible": self.ar_scan_eligible,
+                "with_ar": self.with_ar,
                 # Quest Details
                 # ToDo: Interpret the 'quest_condition' field and use that instead
                 #  of 'quest_type'
@@ -136,6 +151,7 @@ class QuestEvent(BaseEvent):
                 "reward_type_id": self.reward_type_id,
                 "reward_type": locale.get_quest_type_name(self.reward_type_id),
                 "reward_type_raw": self.reward_type_raw,
+                "reward_raw": self.reward_raw,
                 "reward_amount": self.item_amount,
                 "reward": reward_string(self, locale),
                 # Monster Reward Details

--- a/PokeAlarm/Events/RaidEvent.py
+++ b/PokeAlarm/Events/RaidEvent.py
@@ -188,7 +188,7 @@ class RaidEvent(BaseEvent):
                 "spawn_time_raw_hours": egg_spawn[6],
                 "spawn_time_raw_minutes": egg_spawn[7],
                 "spawn_time_raw_seconds": egg_spawn[8],
-                "spawn_time_utc": self.raid_spawn.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "spawn_time_utc": self.egg_spawn_utc.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                 # Hatch Time Remaining
                 "hatch_time_left": raid_start[0],
                 "12h_hatch_time": raid_start[1],
@@ -199,7 +199,7 @@ class RaidEvent(BaseEvent):
                 "hatch_time_raw_hours": raid_start[6],
                 "hatch_time_raw_minutes": raid_start[7],
                 "hatch_time_raw_seconds": raid_start[8],
-                "hatch_time_utc": self.raid_spawn.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "hatch_time_utc": self.raid_start_utc.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                 # Raid Time Remaining
                 "raid_time_left": raid_end[0],
                 "12h_raid_end": raid_end[1],

--- a/PokeAlarm/Events/RaidEvent.py
+++ b/PokeAlarm/Events/RaidEvent.py
@@ -47,10 +47,10 @@ class RaidEvent(BaseEvent):
         self.gym_id = data.get("gym_id")
 
         # Time Remaining
-        self.raid_end = datetime.utcfromtimestamp(
-            data.get("end") or data.get("raid_end")
-        )  # RM or Monocle
-        self.time_left = get_seconds_remaining(self.raid_end)
+        self.egg_spawn_utc = datetime.utcfromtimestamp(data.get("spawn", 0))
+        self.raid_start_utc = datetime.utcfromtimestamp(data.get("start", 0))
+        self.raid_end_utc = datetime.utcfromtimestamp(data.get("end", 0))
+        self.time_left = get_seconds_remaining(self.raid_end_utc)
 
         # Location
         self.lat = float(data["latitude"])
@@ -99,7 +99,7 @@ class RaidEvent(BaseEvent):
         self.charge_duration = get_move_duration(self.charge_id)
         self.charge_energy = get_move_energy(self.charge_id)
 
-        # Gym Details (currently only sent from Monocle)
+        # Gym Details
         self.gym_name = check_for_none(str, data.get("name"), Unknown.REGULAR).strip()
         self.gym_description = check_for_none(
             str, data.get("description"), Unknown.REGULAR
@@ -109,9 +109,15 @@ class RaidEvent(BaseEvent):
         self.guard_count = Unknown.TINY
 
         self.sponsor_id = check_for_none(int, data.get("sponsor"), Unknown.TINY)
+        self.partner_id = check_for_none(
+            int, data.get("partner_id"), Unknown.TINY
+        )  # RDM only
         self.park = check_for_none(str, data.get("park"), Unknown.REGULAR)
         self.ex_eligible = check_for_none(
             int, data.get("is_ex_raid_eligible"), Unknown.REGULAR
+        )
+        self.is_exclusive = check_for_none(
+            int, data.get("is_exclusive"), Unknown.REGULAR
         )
 
         # Gym Team (this is only available from cache)
@@ -147,7 +153,9 @@ class RaidEvent(BaseEvent):
 
     def generate_dts(self, locale, timezone, units):
         """Return a dict with all the DTS for this event."""
-        raid_end_time = get_time_as_str(self.raid_end, timezone)
+        egg_spawn = get_time_as_str(self.egg_spawn_utc, timezone)
+        raid_start = get_time_as_str(self.raid_start_utc, timezone)
+        raid_end = get_time_as_str(self.raid_end_utc, timezone)
         dts = self.custom_dts.copy()
 
         form_name = locale.get_form_name(self.mon_id, self.form_id)
@@ -170,19 +178,39 @@ class RaidEvent(BaseEvent):
             {
                 # Identification
                 "gym_id": self.gym_id,
-                # Time Remaining
-                "raid_time_left": raid_end_time[0],
-                "12h_raid_end": raid_end_time[1],
-                "24h_raid_end": raid_end_time[2],
-                # Time Remaining Without Seconds
-                "raid_time_no_secs": raid_end_time[3],
-                "12h_raid_end_no_secs": raid_end_time[4],
-                "24h_raid_end_no_secs": raid_end_time[5],
-                # Raw time remaining values
-                "raid_time_raw_hours": raid_end_time[6],
-                "raid_time_raw_minutes": raid_end_time[7],
-                "raid_time_raw_seconds": raid_end_time[8],
-                "raid_end_utc": self.raid_end,
+                # Spawn Time
+                "spawn_time": egg_spawn[0],
+                "12h_spawn_time": egg_spawn[1],
+                "24h_spawn_time": egg_spawn[2],
+                "spawn_time_no_secs": egg_spawn[3],
+                "12h_spawn_time_no_secs": egg_spawn[4],
+                "24h_spawn_time_no_secs": egg_spawn[5],
+                "spawn_time_raw_hours": egg_spawn[6],
+                "spawn_time_raw_minutes": egg_spawn[7],
+                "spawn_time_raw_seconds": egg_spawn[8],
+                "spawn_time_utc": self.raid_spawn.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                # Hatch Time Remaining
+                "hatch_time_left": raid_start[0],
+                "12h_hatch_time": raid_start[1],
+                "24h_hatch_time": raid_start[2],
+                "hatch_time_no_secs": raid_start[3],
+                "12h_hatch_time_no_secs": raid_start[4],
+                "24h_hatch_time_no_secs": raid_start[5],
+                "hatch_time_raw_hours": raid_start[6],
+                "hatch_time_raw_minutes": raid_start[7],
+                "hatch_time_raw_seconds": raid_start[8],
+                "hatch_time_utc": self.raid_spawn.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                # Raid Time Remaining
+                "raid_time_left": raid_end[0],
+                "12h_raid_end": raid_end[1],
+                "24h_raid_end": raid_end[2],
+                "raid_time_no_secs": raid_end[3],
+                "12h_raid_end_no_secs": raid_end[4],
+                "24h_raid_end_no_secs": raid_end[5],
+                "raid_time_raw_hours": raid_end[6],
+                "raid_time_raw_minutes": raid_end[7],
+                "raid_time_raw_seconds": raid_end[8],
+                "raid_end_utc": self.raid_end_utc.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                 "current_timestamp_utc": datetime.utcnow(),
                 # Type
                 "type1": type1,
@@ -301,10 +329,14 @@ class RaidEvent(BaseEvent):
                 "sponsored": self.sponsor_id > 0
                 if Unknown.is_not(self.sponsor_id)
                 else Unknown.REGULAR,
+                "partner_id": self.partner_id,
                 "ex_eligible": self.ex_eligible > 0
                 if Unknown.is_not(self.ex_eligible)
                 else Unknown.REGULAR,
                 "ex_eligible_emoji": get_ex_eligible_emoji(self.ex_eligible),
+                "is_exclusive": self.is_exclusive > 0
+                if Unknown.is_not(self.is_exclusive)
+                else Unknown.REGULAR,
                 "park": self.park,
                 "team_id": self.current_team_id,
                 "team_emoji": get_team_emoji(self.current_team_id),

--- a/PokeAlarm/Events/WeatherEvent.py
+++ b/PokeAlarm/Events/WeatherEvent.py
@@ -23,7 +23,8 @@ class WeatherEvent(BaseEvent):
         check_for_none = BaseEvent.check_for_none
 
         # Identification
-        self.s2_cell_id = data.get("s2_cell_id")
+        self.s2_cell_id = check_for_none(int, data.get("s2_cell_id"), Unknown.SMALL)
+        self.s2_cell_coords = check_for_none(str, data.get("coords"), Unknown.SMALL)
 
         # Location
         self.lat = float(data["latitude"])  # To the center of the cell
@@ -33,12 +34,28 @@ class WeatherEvent(BaseEvent):
 
         # Weather Info
         self.weather_id = check_for_none(
-            int, data.get("condition") or data.get("gameplay_weather"), 0
+            int, data.get("condition") or data.get("gameplay_condition"), 0
         )
         self.severity_id = check_for_none(
             int, data.get("alert_severity") or data.get("severity"), 0
         )
         self.day_or_night_id = data.get("day") or data.get("world_time")
+        self.wind_direction = check_for_none(
+            int, data.get("wind_direction"), Unknown.TINY
+        )
+        self.warn_weather = check_for_none(int, data.get("warn_weather"), Unknown.TINY)
+
+        # Weather levels
+        self.cloud_level = check_for_none(int, data.get("cloud_level"), Unknown.TINY)
+        self.rain_level = check_for_none(int, data.get("rain_level"), Unknown.TINY)
+        self.wind_level = check_for_none(int, data.get("wind_level"), Unknown.TINY)
+        self.snow_level = check_for_none(int, data.get("snow_level"), Unknown.TINY)
+        self.fog_level = check_for_none(int, data.get("fog_level"), Unknown.TINY)
+        self.special_effect_level = check_for_none(
+            int, data.get("special_effect_level"), Unknown.TINY
+        )
+
+        self.updated = check_for_none(bool, data.get("updated"), Unknown.TINY)
 
         self.name = self.s2_cell_id
         self.geofence = Unknown.REGULAR
@@ -59,6 +76,7 @@ class WeatherEvent(BaseEvent):
             {
                 # Identification
                 "s2_cell_id": self.s2_cell_id,
+                "s2_cell_coords": self.s2_cell_coords,
                 # Location - center of the s2 cell
                 "lat": self.lat,
                 "lng": self.lng,
@@ -89,6 +107,16 @@ class WeatherEvent(BaseEvent):
                 "day_or_night_id": self.day_or_night_id,
                 "day_or_night_id_3": f"{self.day_or_night_id:03}",
                 "day_or_night": locale.get_day_or_night(self.day_or_night_id),
+                "wind_direction": self.wind_direction,
+                "warn_weather": self.warn_weather,
+                # Weather Levels
+                "cloud_level": self.cloud_level,
+                "rain_level": self.rain_level,
+                "wind_level": self.wind_level,
+                "snow_level": self.snow_level,
+                "fog_level": self.fog_level,
+                "special_effect_level": self.special_effect_level,
+                "updated": self.updated,
                 "current_timestamp_utc": datetime.utcnow(),
             }
         )

--- a/PokeAlarm/Events/__init__.py
+++ b/PokeAlarm/Events/__init__.py
@@ -36,10 +36,8 @@ def event_factory(data):
         elif kind == "gym" or kind == "gym_details":
             return GymEvent(message)
         elif kind == "raid" and not message.get("pokemon_id"):
-            # RM sends None, M sends 0 for eggs
             return EggEvent(message)
         elif kind == "raid" and message.get("pokemon_id"):
-            # RM/M send Monster ID in raids
             return RaidEvent(message)
         elif kind == "weather":
             return WeatherEvent(message)

--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -991,10 +991,10 @@ class Manager(object):
                 "Egg %s was skipped because it was previously processed.", egg.name
             )
             return
-        self.__cache.egg_expiration(egg.gym_id, egg.hatch_time)
+        self.__cache.egg_expiration(egg.gym_id, egg.raid_start_utc)
 
         # Check the time remaining
-        seconds_left = (egg.hatch_time - datetime.utcnow()).total_seconds()
+        seconds_left = (egg.raid_start_utc - datetime.utcnow()).total_seconds()
         if seconds_left < self.__time_limit:
             self._log.debug(
                 "Egg %s was skipped because only %s seconds remained",
@@ -1057,10 +1057,10 @@ class Manager(object):
                 "Raid %s was skipped because it was previously processed.", raid.name
             )
             return
-        self.__cache.raid_expiration(raid.gym_id, raid.raid_end)
+        self.__cache.raid_expiration(raid.gym_id, raid.raid_end_utc)
 
         # Check the time remaining
-        seconds_left = (raid.raid_end - datetime.utcnow()).total_seconds()
+        seconds_left = (raid.raid_end_utc - datetime.utcnow()).total_seconds()
         if seconds_left < self.__time_limit:
             self._log.debug(
                 "Raid %s was skipped because only %s seconds remained",

--- a/tests/filters/test_weather_filter.py
+++ b/tests/filters/test_weather_filter.py
@@ -23,7 +23,7 @@ class TestWeatherFilter(unittest.TestCase):
             "s2_cell_id": 0,
             "latitude": 37.7876146,
             "longitude": -122.390624,
-            "gameplay_weather": 1,
+            "condition": 1,
             "severity": 0,
             "world_time": 1,
         }
@@ -106,7 +106,7 @@ class TestWeatherFilter(unittest.TestCase):
     @generic_filter_test
     def test_weather(self):
         self.filt = {"weather": [1, 5, "Cloudy"]}
-        self.event_key = "gameplay_weather"
+        self.event_key = "condition"
         self.pass_vals = [1]
         self.fail_vals = [2]
 

--- a/tools/webhook_test.py
+++ b/tools/webhook_test.py
@@ -172,7 +172,7 @@ def set_init(webhook_type):
                 "s2_cell_id": current_time,
                 "latitude": 37.7876146,
                 "longitude": -122.390624,
-                "gameplay_weather": 0,
+                "condition": 0,
                 "severity": 0,
                 "world_time": 1,
             },
@@ -557,7 +557,7 @@ elif type == whtypes["5"]:
 elif type == whtypes["6"]:
     print("What type of weather would you like to report? (default: 0)")
     print(weather_formatted, end="\n> ")
-    int_or_default("gameplay_weather")
+    int_or_default("condition")
     print("What type of severity status would you like? (default: 0)")
     print(severity_formatted, end="\n> ")
     int_or_default("severity")


### PR DESCRIPTION
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->

<!--
 Please make all PRs to the dev branch. The dev branch will be
 periodically pulled into the master branch. This allows time for
 the changes and documentation to be tested before being exposed to
 a wider population.
--->

## Description
<!-- In detail, describe what your PR adds to PokeAlarm -->

This PR brings a full support to the current working scanners: RealDeviceMap (RDM) and Map'A'Droid (MAD).

More than 90 DTS has been added or repaired for at least one of these scanners.
I prepared a full list of the DTS changes in question:

✔️ : New DTS
🗸 : Still working
🛠️ : DTS repaired
❌ : Not available

| Event | DTS | MAD | RDM |
| ---- | ---- | ---- | ---- |
| EggEvent | `spawn_time`| ✔️ | ✔️ |
| EggEvent | `12h_spawn_time`| ✔️ | ✔️ |
| EggEvent | `24h_spawn_time`| ✔️ | ✔️ |
| EggEvent | `spawn_time_no_secs`| ✔️ | ✔️ |
| EggEvent | `12h_spawn_time_no_secs`| ✔️ | ✔️ |
| EggEvent | `24h_spawn_time_no_secs`| ✔️ | ✔️ |
| EggEvent | `spawn_time_raw_hours`| ✔️ | ✔️ |
| EggEvent | `spawn_time_raw_minutes`| ✔️ | ✔️ |
| EggEvent | `spawn_time_raw_seconds`| ✔️ | ✔️ |
| EggEvent | `spawn_time_utc`| ✔️ | ✔️ |
| EggEvent | `gym_name`| 🗸 | 🛠️ |
| EggEvent | `gym_image`| 🗸 | 🛠️ |
| EggEvent | `partner_id`| ❌ | ✔️ |
| EggEvent | `ex_eligible`| 🗸 | 🛠️ |
| GymEvent | `ex_eligible`| 🗸 | 🛠️ |
| GymEvent | `guard_pokemon_id`| ❌ | ✔️ |
| GymEvent | `total_cp`| ❌ | ✔️ |
| GymEvent | `in_battle`| ✔️ | ✔️ |
| GymEvent | `power_up_points`| ❌ | ✔️ |
| GymEvent | `power_up_level`| ❌ | ✔️ |
| GymEvent | `power_up_end_timestamp`| ❌ | ✔️ |
| GymEvent | `sponsor_id`| 🗸 | 🛠️ |
| GymEvent | `partner_id`| ❌ | ✔️ |
| GymEvent | `ar_scan_eligible`| ✔️ | ✔️ |
| MonEvent | `cp_multiplier`| ✔️ | ❌ |
| MonEvent | `pokestop_id`| ✔️ | ✔️ |
| MonEvent | `pokestop_name`| ✔️ | ❌ |
| MonEvent | `pokestop_url`| ✔️ | ❌ |
| MonEvent | `cell_coords`| ✔️ | ❌ |
| MonEvent | `cell_id`| ✔️ | ❌ |
| MonEvent | `first_seen`| ❌ | ✔️ |
| MonEvent | `size_id`| 🗸 | 🛠️ |
| MonEvent | `is_shiny`| ❌ | ✔️ |
| MonEvent | `is_event`| ❌ | ✔️ |
| MonEvent | `seen_type`| ✔️ | ✔️ |
| QuestEvent | `quest_type`| 🗸 | 🛠️ |
| QuestEvent | `quest_target`| 🗸 | 🛠️ |
| QuestEvent | `quest_condition`| 🗸 | 🛠️ |
| QuestEvent | `quest_template`| 🗸 | 🛠️ |
| QuestEvent | `reward_raw`| ✔️ | ✔️ |
| QuestEvent | `ar_scan_eligible`| ✔️ | ✔️ |
| QuestEvent | `with_ar`| ❌ | ✔️ |
| QuestEvent | `last_modified`| 🗸 | 🛠️ |
| GruntEvent | `start_time`| ✔️ | ✔️ |
| GruntEvent | `12h_start_time`| ✔️ | ✔️ |
| GruntEvent | `24h_start_time`| ✔️ | ✔️ |
| GruntEvent | `start_time_no_secs`| ✔️ | ✔️ |
| GruntEvent | `12h_start_time_no_secs`| ✔️ | ✔️ |
| GruntEvent | `24h_start_time_no_secs`| ✔️ | ✔️ |
| GruntEvent | `start_time_raw_hours`| ✔️ | ✔️ |
| GruntEvent | `start_time_raw_minutes`| ✔️ | ✔️ |
| GruntEvent | `start_time_raw_seconds`| ✔️ | ✔️ |
| GruntEvent | `start_utc`| ✔️ | ✔️ |
| GruntEvent | `display_type`| ✔️ | ✔️ |
| GruntEvent | `style`| ✔️ | ✔️ |
| RaidEvent | `partner_id`| ❌ | ✔️ |
| RaidEvent | `is_exclusive`| ✔️ | ✔️ |
| RaidEvent | `spawn_time`| ✔️ | ✔️ |
| RaidEvent | `12h_spawn_time`| ✔️ | ✔️ |
| RaidEvent | `24h_spawn_time`| ✔️ | ✔️ |
| RaidEvent | `spawn_time_no_secs`| ✔️ | ✔️ |
| RaidEvent | `12h_spawn_time_no_secs`| ✔️ | ✔️ |
| RaidEvent | `24h_spawn_time_no_secs`| ✔️ | ✔️ |
| RaidEvent | `spawn_time_raw_hours`| ✔️ | ✔️ |
| RaidEvent | `spawn_time_raw_minutes`| ✔️ | ✔️ |
| RaidEvent | `spawn_time_raw_seconds`| ✔️ | ✔️ |
| RaidEvent | `spawn_time_utc`| ✔️ | ✔️ |
| RaidEvent | `hatch_time`| ✔️ | ✔️ |
| RaidEvent | `12h_hatch_time`| ✔️ | ✔️ |
| RaidEvent | `24h_hatch_time`| ✔️ | ✔️ |
| RaidEvent | `hatch_time_no_secs`| ✔️ | ✔️ |
| RaidEvent | `12h_hatch_time_no_secs`| ✔️ | ✔️ |
| RaidEvent | `24h_hatch_time_no_secs`| ✔️ | ✔️ |
| RaidEvent | `hatch_time_raw_hours`| ✔️ | ✔️ |
| RaidEvent | `hatch_time_raw_minutes`| ✔️ | ✔️ |
| RaidEvent | `hatch_time_raw_seconds`| ✔️ | ✔️ |
| RaidEvent | `hatch_time_utc`| ✔️ | ✔️ |
| StopEvent | `power_up_points`| ❌ | ✔️ |
| StopEvent | `power_up_level`| ❌ | ✔️ |
| StopEvent | `power_up_end_timestamp`| ❌ | ✔️ |
| StopEvent | `ar_scan_eligible`| ❌ | ✔️ |
| StopEvent | `stop_description`| ❌ | ✔️ |
| WeatherEvent | `weather_id`| 🗸 | 🛠️ |
| WeatherEvent | `s2_cell_coords`| ✔️ | ❌ |
| WeatherEvent | `updated`| ✔️ | ✔️ |
| WeatherEvent | `wind_direction`| ❌ | ✔️ |
| WeatherEvent | `warn_weather`| ❌ | ✔️ |
| WeatherEvent | `cloud_level`| ❌ | ✔️ |
| WeatherEvent | `rain_level`| ❌ | ✔️ |
| WeatherEvent | `wind_level`| ❌ | ✔️ |
| WeatherEvent | `snow_level`| ❌ | ✔️ |
| WeatherEvent | `fog_level`| ❌ | ✔️ |
| WeatherEvent | `special_effect_level`| ❌ | ✔️ |

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (would cause existing functionality to change)

## Motivation and Context
<!---
 Why is this change required? What problem does it solve?
 If it fixes an open issue, please link to the issue here.
-->
A lot of essential DTS were missing for RDM.
A lot more were also broken for one of the scanners.

This PR resolves #834.

## How Has This Been Tested?
<!---
 Please describe in detail how you tested your changes. Make sure to
 describe what tests you have performed, your testing environment,
 and if you have used this in a production setting. Please add
 screenshots if appropriate.
-->
On my live config using a MAD scanner, there is no crash and every notifications are still working fine. But given I'm not using RDM, I can't confirm the new exclusive DTS for it are 100% working. Anyway, it shouldn't make us crash.

```diff
- Because the changes are important, I would need at least 1 working test confirmations for each scanner (RDM and MAD).
```
## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change in doc/*.rst files.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [x] This change requires an update to the Wiki but doesn't include it.
- [ ] This change does not require an update to the Wiki.