### PR TITLE
Empty keys in Discord webbook are filtered to prevent from denying the webhook

### DIFF
--- a/PokeAlarm/Alarms/Discord/DiscordAlarm.py
+++ b/PokeAlarm/Alarms/Discord/DiscordAlarm.py
@@ -253,10 +253,13 @@ class DiscordAlarm(Alarm):
                     "title": replace(alert["title"], info),
                     "url": replace(alert["url"], info),
                     "description": replace(alert["body"], info),
-                    "thumbnail": {"url": replace(alert["icon_url"], info)},
                     "fields": self.replace_fields(alert["fields"], info),
                 }
             ]
+
+            thumbnail_url = replace(alert["icon_url"], info)
+            if thumbnail_url != "":
+                payload["embeds"][0]["thumbnail"] = {"url": thumbnail_url}
 
             if alert["map"] is not None:
                 static_map_url = ""
@@ -270,10 +273,22 @@ class DiscordAlarm(Alarm):
                             static_map_url, self.__signing_secret_key
                         )
 
-                payload["embeds"][0]["image"] = {"url": static_map_url}
+                if static_map_url != "":
+                    payload["embeds"][0]["image"] = {"url": static_map_url}
 
             if "timestamp" in alert:
                 payload["embeds"][0]["timestamp"] = replace(alert["timestamp"], info)
+
+        # Remove empty keys because Discord doesn't accept them
+        for key in list(payload):
+            if payload[key] == "":
+                payload.pop(key)
+
+        if "embeds" in payload:
+            for key in list(payload["embeds"]):
+                if payload["embeds"][key] == "":
+                    payload["embeds"].pop(key)
+
         args = {"url": replace(alert["webhook_url"], info), "payload": payload}
 
         try_sending(


### PR DESCRIPTION
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->


<!--
 Please make all PRs to the dev branch. The dev branch will be
 periodically pulled into the master branch. This allows time for
 the changes and documentation to be tested before being exposed to
 a wider population.
--->

## Description
<!-- In detail, describe what your PR adds to PokeAlarm -->

Empty keys in Discord webbook are filtered to prevent from denying the webhook

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
<!---
 Why is this change required? What problem does it solve?
 If it fixes an open issue, please link to the issue here.
-->

Some alarms are not accepted by Discord because some fields are empty.
Resolves #862

## How Has This Been Tested?
<!---
 Please describe in detail how you tested your changes. Make sure to
 describe what tests you have performed, your testing environment,
 and if you have used this in a production setting. Please add
 screenshots if appropriate.
-->

## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change in doc/*.rst files.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [ ] This change requires an update to the Wiki.
- [x] This change does not require an update to the Wiki.