### PR TITLE
fix several TypeErrors in generate_dts() with unknown mon values

### DIFF
--- a/PokeAlarm/Events/MonEvent.py
+++ b/PokeAlarm/Events/MonEvent.py
@@ -89,7 +89,7 @@ class MonEvent(BaseEvent):
         self.atk_iv = check_for_none(int, data.get("individual_attack"), Unknown.TINY)
         self.def_iv = check_for_none(int, data.get("individual_defense"), Unknown.TINY)
         self.sta_iv = check_for_none(int, data.get("individual_stamina"), Unknown.TINY)
-        if Unknown.is_not(self.atk_iv, self.def_iv, self.sta_iv):
+        if Unknown.is_not(self.atk_iv, self.def_iv, self.sta_iv, self.mon_lvl):
             self.iv = 100 * (self.atk_iv + self.def_iv + self.sta_iv) / float(45)
             (
                 self.great_product,
@@ -112,6 +112,8 @@ class MonEvent(BaseEvent):
                 self.sta_iv,
                 self.mon_lvl,
             )
+            self.great_stardust = f"{self.great_stardust:,}".replace(",", " ")
+            self.ultra_stardust = f"{self.ultra_stardust:,}".replace(",", " ")
         else:
             self.iv = Unknown.SMALL
             self.great_product = Unknown.SMALL
@@ -431,7 +433,7 @@ class MonEvent(BaseEvent):
                 ),
                 "great_pvpoke": f"https://{pvpoke_domain}/rankings/all/1500/overall/{great_pvpoke_monster_formatted}/",
                 "great_candy": great_candy,
-                "great_stardust": f"{self.great_stardust:,}".replace(",", " "),
+                "great_stardust": self.great_stardust,
                 "ultra_mon_id": self.ultra_id,
                 "ultra_product": self.ultra_product,
                 "ultra_mon_name": locale.get_pokemon_name(self.ultra_id),
@@ -451,7 +453,7 @@ class MonEvent(BaseEvent):
                 ),
                 "ultra_pvpoke": f"https://{pvpoke_domain}/rankings/all/2500/overall/{ultra_pvpoke_monster_formatted}/",
                 "ultra_candy": ultra_candy,
-                "ultra_stardust": f"{self.ultra_stardust:,}".replace(",", " "),
+                "ultra_stardust": self.ultra_stardust,
                 # Type
                 "type1": type1,
                 "type1_or_empty": Unknown.or_empty(type1),

--- a/PokeAlarm/Events/MonEvent.py
+++ b/PokeAlarm/Events/MonEvent.py
@@ -227,10 +227,37 @@ class MonEvent(BaseEvent):
             self.monster_id, last_evo_id, evolutions, evolution_costs
         )
 
+        if Unknown.is_not(self.atk_iv, self.def_iv, self.sta_iv):
+            max_cp_ = calculate_cp(
+                self.monster_id,
+                self.form_id,
+                self.atk_iv,
+                self.def_iv,
+                self.sta_iv,
+                50,
+            )
+            max_evo_cp_ = calculate_cp(
+                last_evo_id,
+                last_evo_form_id,
+                self.atk_iv,
+                self.def_iv,
+                self.sta_iv,
+                50,
+            )
+        else:
+            max_cp_ = Unknown.TINY
+            max_evo_cp_ = Unknown.TINY
+
         # Remove ".0" from full PvP levels
-        if Unknown.is_not(self.great_level) and int(self.great_level) == self.great_level:
+        if (
+            Unknown.is_not(self.great_level)
+            and int(self.great_level) == self.great_level
+        ):
             self.great_level = int(self.great_level)
-        if Unknown.is_not(self.ultra_level) and int(self.ultra_level) == self.ultra_level:
+        if (
+            Unknown.is_not(self.ultra_level)
+            and int(self.ultra_level) == self.ultra_level
+        ):
             self.ultra_level = int(self.ultra_level)
 
         # Stringify PvP candy costs
@@ -366,25 +393,11 @@ class MonEvent(BaseEvent):
                 "mon_lvl": self.mon_lvl,
                 "cp": self.cp,
                 # Max out
-                "max_cp": calculate_cp(
-                    self.monster_id,
-                    self.form_id,
-                    self.atk_iv,
-                    self.def_iv,
-                    self.sta_iv,
-                    50,
-                ),
+                "max_cp": max_cp_,
                 "max_perfect_cp": max_cp(self.monster_id, self.form_id),
                 "stardust_cost": calculate_stardust_cost(self.mon_lvl, 50),
                 "candy_cost": calculate_candy_cost(self.mon_lvl, 50),
-                "max_evo_cp": calculate_cp(
-                    last_evo_id,
-                    last_evo_form_id,
-                    self.atk_iv,
-                    self.def_iv,
-                    self.sta_iv,
-                    50,
-                ),
+                "max_evo_cp": max_evo_cp_,
                 "max_perfect_evo_cp": max_cp(last_evo_id, last_evo_form_id),
                 "candy_cost_with_evo": calculate_candy_cost(
                     self.mon_lvl, 50, evo_candy_cost

--- a/PokeAlarm/Utils.py
+++ b/PokeAlarm/Utils.py
@@ -752,7 +752,7 @@ def get_xl_candy_costs():
 
 
 def calculate_candy_cost(start_level, target_level, evo_candy_cost=0):
-    if start_level >= target_level:
+    if Unknown.is_(start_level) or start_level >= target_level:
         return (0, 0)
 
     candy_costs = get_candy_costs()
@@ -771,7 +771,7 @@ def calculate_candy_cost(start_level, target_level, evo_candy_cost=0):
 
 
 def calculate_stardust_cost(start_level, target_level):
-    if start_level >= target_level:
+    if Unknown.is_(start_level) or start_level >= target_level:
         return 0
 
     stardust_costs = get_stardust_costs()


### PR DESCRIPTION
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->
<!--         PULL REQUESTS CREATED NOT USING THE TEMPLATE           --->
<!--              WILL BE CLOSED WITHOUT ANY RESPONSE               --->


<!--
 Please make all PRs to the dev branch. The dev branch will be
 periodically pulled into the master branch. This allows time for
 the changes and documentation to be tested before being exposed to
 a wider population.
--->

## Description
<!-- In detail, describe what your PR adds to PokeAlarm -->
When mon without encounter values generate an alarm calculate_cp(),  calculate_candy_cost() and calculate_stardust_cost() called from within generate_dts() fail with an exception, since the values are Unknown.TINY strings and not ints.

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
<!---
 Why is this change required? What problem does it solve?
 If it fixes an open issue, please link to the issue here.
-->
Users reported TypeErrors with MonEvent:
## 1
```
2023-02-06 18:08:24,809 [ERROR][ pokealarm][  man_1] Encountered error during processing: TypeError: unsupported operand type(s) for +: 'int' and 'str'
2023-02-06 18:08:24,810 [ERROR][ pokealarm][  man_1] Stack trace:
 Traceback (most recent call last):
  File "/opt/PokeAlarm/PokeAlarm/Manager.py", line 651, in run
    self.process_monster(event)
  File "/opt/PokeAlarm/PokeAlarm/Manager.py", line 817, in process_monster
    self._notify_alarms(mon, rule.alarm_names, "pokemon_alert")
  File "/opt/PokeAlarm/PokeAlarm/Manager.py", line 727, in _notify_alarms
    dts = event.generate_dts(self.__locale, self.__timezone, self.__units)
  File "/opt/PokeAlarm/PokeAlarm/Events/MonEvent.py", line 329, in generate_dts
    50,
  File "/opt/PokeAlarm/PokeAlarm/Utils.py", line 544, in calculate_cp
    cp_base = calculate_cp_base(monster_id, form_id, atk, de, sta)
  File "/opt/PokeAlarm/PokeAlarm/Utils.py", line 554, in calculate_cp_base
    / 10
TypeError: unsupported operand type(s) for +: 'int' and 'str'
```
## 2
```
2023-04-08 16:38:52,569 [ERROR][ pokealarm][ manager_0] Stack trace:
 Traceback (most recent call last):
  File "/home/user001/PokeAlarm/PokeAlarm/Manager.py", line 615, in run
    self.process_monster(event)
  File "/home/user001/PokeAlarm/PokeAlarm/Manager.py", line 772, in process_monster
    self._notify_alarms(mon, rule.alarm_names, "pokemon_alert")
  File "/home/user001/PokeAlarm/PokeAlarm/Manager.py", line 686, in _notify_alarms
    dts = event.generate_dts(self.locale, self.timezone, self.__units)
  File "/home/user001/PokeAlarm/PokeAlarm/Events/MonEvent.py", line 392, in generate_dts
    "stardust_cost": calculate_stardust_cost(self.mon_lvl, 50),
  File "/home/user001/PokeAlarm/PokeAlarm/Utils.py", line 774, in calculate_stardust_cost
    if start_level >= target_level:
TypeError: '>=' not supported between instances of 'str' and 'int'
```
## 3
```
2023-04-08 20:13:52,760 [ERROR][ pokealarm][ manager_0] Stack trace:
 Traceback (most recent call last):
  File "/home/user001/pokealarm/PokeAlarm/Manager.py", line 616, in run
    self.process_monster(event)
  File "/home/user001/pokealarm/PokeAlarm/Manager.py", line 773, in process_monster
    self._notify_alarms(mon, rule.alarm_names, "pokemon_alert")
  File "/home/user001/pokealarm/PokeAlarm/Manager.py", line 687, in _notify_alarms
    dts = event.generate_dts(self.locale, self.timezone, self.__units)
  File "/home/user001/pokealarm/PokeAlarm/Events/MonEvent.py", line 454, in generate_dts
    "ultra_stardust": f"{self.ultra_stardust:,}".replace(",", " "),
ValueError: Cannot specify ',' with 's'.
```
## How Has This Been Tested?
<!---
 Please describe in detail how you tested your changes. Make sure to
 describe what tests you have performed, your testing environment,
 and if you have used this in a production setting. Please add
 screenshots if appropriate.
-->
Waiting for feedback from original reporters.

## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change in doc/*.rst files.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [ ] This change requires an update to the Wiki.
- [x] This change does not require an update to the Wiki.